### PR TITLE
release quick start

### DIFF
--- a/sidebar.json
+++ b/sidebar.json
@@ -93,8 +93,7 @@
     "contents": [
       {
         "name": "Quick Start Guide",
-        "slug": "quick-start",
-        "dev": true
+        "slug": "quick-start"
       },
       {
         "name": "Using Repl.it for Free",


### PR DESCRIPTION
Takes the `dev` flag off the quick start on the sidebar