### PR TITLE
Fixed JS typo secret-keys.md

### DIFF
--- a/repls/secret-keys.md
+++ b/repls/secret-keys.md
@@ -51,7 +51,7 @@ print(os.getenv("DB_USERNAME"))
 ### JavaScript
 
 ```javascript
-print(process.env.TOKEN)
+console.log(process.env.TOKEN)
 // prints '38zdJSDF48fKJSD4824fN'
 ```
 


### PR DESCRIPTION
The JavaScript example had `print(process.env.TOKEN)` instead of `console.log(process.env.TOKEN)`