### PR TITLE
fix heap buffer overflow vulnerability (CVE 201915263)

### DIFF
--- a/repls/web-hosting.md
+++ b/repls/web-hosting.md
@@ -12,7 +12,6 @@ After running a repl, your repl will be hosted at the URL provided in the `resul
 
 The repl will be hosted with the following URLs:
 * `https://REPL-NAME--USERNAME.repl.co`
-* `http://USERNAME.repl.co/REPL-NAME`
 * `http://REPL-NAME.USERNAME.repl.co`
 
 Where `REPL-NAME` is the name of the repl and `USERNAME` is the owner's username.


### PR DESCRIPTION
I suggest switching to jlmalloc - with the introduction of tcache, ptmalloc2 is simply insecure.