### PR TITLE
Add requirements for DMCA takedown request

### DIFF
--- a/misc/copyright.md
+++ b/misc/copyright.md
@@ -8,3 +8,12 @@ In the case of either of the following:
 * Personal/private information is contained within a public/private repl, or a public/private classroom assignment
 
 Please [contact us](mailto:contact@repl.it) immediately and we will remove it.  It is against our [Terms and Conditions](https://repl.it/site/terms) for users to publish any content that violates privacy rights, publicity rights, copyrights, or contract rights.
+
+Per the Digital Millennium Copyright Act (DMCA, see 17 U.S.C 512(c)(3) for details), we require the following information in writing for DMCA takedown requests:
+
+- an electronic or physical signature of the person authorized to act on behalf of the owner of the copyright's interest;
+- a description of the copyrighted work that you claim has been infringed, including the URL (i.e., web page address) of the location where the copyrighted work exists or a copy of the copyrighted work;
+-identification of the URL or other specific location on the Service where the material that you claim is infringing is located;
+- your address, telephone number, and email address;
+- a statement by you that you have a good faith belief that the disputed use is not authorized by the copyright owner, its agent, or the law;
+- a statement by you, made under penalty of perjury, that the above information in your notice is accurate and that you are the copyright owner or authorized to act on the copyright owner's behalf.


### PR DESCRIPTION
The requirements for a complete DMCA takedown request are strict, which are only located in our [terms](https://repl.it/site/terms). For clarity, they should also be included here as well.