### PR TITLE
remove ruby references

### DIFF
--- a/repls/http-servers.md
+++ b/repls/http-servers.md
@@ -23,8 +23,8 @@ fork it or play around with it.
 
 <iframe height="400px" width="100%" src="https://repl.it/@timmy_i_chen/flask-boilerplate?lite=true" scrolling="no" frameborder="no" allowtransparency="true" allowfullscreen="true" sandbox="allow-forms allow-pointer-lock allow-popups allow-same-origin allow-scripts allow-modals"></iframe>
 
-We highly recommend using `requirements.txt` or `package.json` files for Python and Node/Express, respectively.  See our
-documentation on [libraries](/repls/packages) for more information on dependencies.
+Our [package manager](https://github.com/replit/upm) will create `requirements.txt`/`package.json` files automatically in your repls.  See our
+documentation on [packages](/repls/packages) for more information on how to install and manage dependencies.
 
 Private keys to external services or APIs can be kept in an `.env` file.
 See our documentation on [secret keys](/repls/secret-keys).

--- a/repls/http-servers.md
+++ b/repls/http-servers.md
@@ -23,9 +23,8 @@ fork it or play around with it.
 
 <iframe height="400px" width="100%" src="https://repl.it/@timmy_i_chen/flask-boilerplate?lite=true" scrolling="no" frameborder="no" allowtransparency="true" allowfullscreen="true" sandbox="allow-forms allow-pointer-lock allow-popups allow-same-origin allow-scripts allow-modals"></iframe>
 
-We highly recommend using a `requirements.txt` file, `package.json` file, or
-`Gemfile` for Python, Node/Express, and Ruby web apps, respectively.  See our
-documentation on [libraries](/repls/packages).
+We highly recommend using `requirements.txt` or `package.json` files for Python and Node/Express, respectively.  See our
+documentation on [libraries](/repls/packages) for more information on dependencies.
 
 Private keys to external services or APIs can be kept in an `.env` file.
 See our documentation on [secret keys](/repls/secret-keys).

--- a/repls/http-servers.md
+++ b/repls/http-servers.md
@@ -23,7 +23,7 @@ fork it or play around with it.
 
 <iframe height="400px" width="100%" src="https://repl.it/@timmy_i_chen/flask-boilerplate?lite=true" scrolling="no" frameborder="no" allowtransparency="true" allowfullscreen="true" sandbox="allow-forms allow-pointer-lock allow-popups allow-same-origin allow-scripts allow-modals"></iframe>
 
-Our [package manager](https://github.com/replit/upm) will create `requirements.txt`/`package.json` files automatically in your repls.  See our
+Our [package manager](https://github.com/replit/upm) will handle dependency files automatically in your repls.  See our
 documentation on [packages](/repls/packages) for more information on how to install and manage dependencies.
 
 Private keys to external services or APIs can be kept in an `.env` file.

--- a/repls/packages.md
+++ b/repls/packages.md
@@ -1,6 +1,6 @@
 # Installing Packages
 
-You can use most packages available in Python, Javascript, and Ruby. Repl.it will install many packages on the fly just by importing them in code. You can read more about how we do this using [upm](https://blog.repl.it/upm).
+You can use most packages available in Python and Javascript. Repl.it will install many packages on the fly just by importing them in code. You can read more about how we do this using [upm](https://blog.repl.it/upm).
 
 ## Searching and Adding Packages
 
@@ -29,21 +29,7 @@ JavaScript:
 const express = require('express');
 ```
 
-Doing so will install the latest version of the package into your repl. A spec file and lock file will be created so the versions won't change.
-
-Ruby works a bit differently.  To import a package in Ruby, you'll have to use `bundler/inline`
-to define the gemspec within the code.  As an example, it may look like this:
-
-```ruby
-require 'bundler/inline'
-
-gemfile true do
- source 'http://rubygems.org'
- gem 'colorize'
-end
-```
-
-Wherever possible, we recommend using a file to manage dependencies.
+Doing so will install the latest version of the package into your repl. A spec file and lock file will be created so the versions won't change. Wherever possible, we recommend using a file to manage dependencies.
 
 ## Spec Files
 
@@ -51,7 +37,6 @@ Each language has a file that is used to describe the project's required package
 
 * Python: `pyproject.toml`
 * JavaScript (Node.js): `package.json`
-* Ruby: `Gemfile`
 
 ### Python
 
@@ -106,18 +91,3 @@ Note that all the packages are being installed with their latest version.  You c
 
 This will install `express` at version 4.16.3 or newer, `body-parser` at the latest version,
 and `sqlite3` at exactly version 3.1.12.
-
-### Ruby
-
-In Ruby, you can use a `Gemfile`.  In this file, you simple start with
-`source 'https://rubygems.org'` followed by the gems you want to install.  As an example,
-from our [rails boilerplate](https://repl.it/@timmy_i_chen/rails-template), a `Gemfile` may
-look like:
-
-```ruby
-source 'https://rubygems.org'
-
-gem 'rails', '~> 5.1.5'
-gem 'sqlite3'
-gem 'tzinfo-data'
-```

--- a/repls/secret-keys.md
+++ b/repls/secret-keys.md
@@ -19,7 +19,7 @@ DB_PASSWORD=w0ws0secure!!
 
 ## Reading env Files
 
-Your Repl will automatically load the contents of your `.env` file into your environment so that they can be read.  Here are the ways you can access them in Python, JavaScript, and Ruby, given the following `.env` file:
+Your Repl will automatically load the contents of your `.env` file into your environment so that they can be read.  Here are the ways you can access them in Python and JavaScript, given the following `.env` file:
 
 ```
 # super secret token
@@ -41,13 +41,6 @@ print(os.getenv("DB_USERNAME"))
 ```javascript
 console.log(process.env.TOKEN)
 // prints '38zdJSDF48fKJSD4824fN'
-```
-
-### Ruby
-
-```ruby
-puts ENV["DB_PASSWORD"]
-# prints 'old_passw0rd-w00t'
 ```
 
 For security reasons, we do not recommend storing `.env` files in html repls. They'll be served to anyone who requests `/.env`.


### PR DESCRIPTION
Deemphasizing ruby in documentation, as ruby doesn't currently run on [polygott](https://github.com/replit/polygott).