### PR TITLE
fix unknown title

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ const render = async (res, category, slug) => {
 	const cobj = t.find(c => c.slug === category);
 	const dobj = cobj.contents.find(d => d.slug === slug)
 
-	res.locals.title = `Repl.it - ${ dobj? dobj.name : 'unknown'}`;
+	res.locals.title = `Repl.it - ${ dobj? dobj.name : slug }`;
 	res.render('index.ejs');
 }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2641205/101026683-dffdc100-357f-11eb-9444-333d1db08166.png)

fall back to slug instead of 'unknown' for the tab title of articles that aren't in the sidebar

motivation: starting to include some article 'collections' (eg. autograding, example homework assignments) where it doesn't make sense to have each one have its own entry, but the 'unknown' looks messy in these cases.