### PR TITLE
fix null cobj dboj

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ const render = async (res, category, slug) => {
 	res.locals.active = category + '/' + slug;
 
 	const cobj = t.find(c => c.slug === category);
-	const dobj = cobj? cobj.contents.find(d => d.slug === slug) : {"name": ""}
+	const dobj = cobj? cobj.contents.find(d => d.slug === slug) : {"name": slug}
 
   if (category === 'repls' && slug === 'intro') {
     // landing page gets a short title for search engine visibility

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ const render = async (res, category, slug) => {
 	res.locals.active = category + '/' + slug;
 
 	const cobj = t.find(c => c.slug === category);
-	const dobj = cobj.contents.find(d => d.slug === slug)
+	const dobj = cobj? cobj.contents.find(d => d.slug === slug) : {"name": ""}
 
   if (category === 'repls' && slug === 'intro') {
     // landing page gets a short title for search engine visibility


### PR DESCRIPTION
For files that are not listed in the sidebar, `cobj` is null, and this calls the next line to throw an exception.

This means that we cannot render articles that are not included in the sidebar.

We need to do this in a few cases, so this now defaults them to having just the default "Replit Docs" title, without the additional sidebar title as the main HTML title.