### PR TITLE
add 404

### DIFF
--- a/index.js
+++ b/index.js
@@ -267,7 +267,7 @@ app.get('/:category/:slug', async (req, res) => {
 	const { category, slug } = req.params;
 	render(res, category, slug)
 		.catch(err => {
-			res.send(`
+			res.send(404, `
               <h1>Something went wrong!</h1 >
               <p>maybe you can <a href="https://replit.com/@util/replit-docs">help fix it</a></p>
             `);


### PR DESCRIPTION
* this doesn't account for all possible errors, but the most common time for this to be triggered is when someone visits a page that doesn't exist
* by adding this 404 we can find broken internal links more easily.