### PR TITLE
Fixed a bunch of broken links

### DIFF
--- a/hosting/embedding-repls.md
+++ b/hosting/embedding-repls.md
@@ -34,12 +34,12 @@ Note: To embed the spotlight view, use `?embed=true` instead of `?lite=true`.
 
 ## Embedding on WordPress
 
-WordPress supports OEmbed but can only embed content from an approved whitelist of websites. Check out the [WordPress documentation](https://wordpress.org/support/article/embeds/#adding-support-for-an-oembed-enabled-site) for instructions to add Replit to the whitelist. Once Replit is added, a repl URL formatted as https://replit.com/@username/repltitle will automatically embed an interactive copy of the repl into your WordPress site.
+WordPress supports OEmbed but can only embed content from an approved whitelist of websites. Check out the [WordPress documentation](https://wordpress.org/support/article/embeds/#adding-support-for-an-oembed-enabled-site) for instructions to add Replit to the whitelist. Once Replit is added, a repl URL formatted as `https://replit.com/@username/repltitle` will automatically embed an interactive copy of the repl into your WordPress site.
 
 ## Embedding on Medium via Embedly
 
 To embed your repl on Medium, simply paste the repl link
-(https://replit.com/@username/repl-name) into your medium post and hit "Enter". The repl should automatically be converted to the interactive IDE, where you can edit and run code. To resize the embedded repl, click on it, then select one of four choices that Medium presents to you.
+`https://replit.com/@username/repl-name` into your medium post and hit "Enter". The repl should automatically be converted to the interactive IDE, where you can edit and run code. To resize the embedded repl, click on it, then select one of four choices that Medium presents to you.
 
 ## Editing an Embedded Repl
 

--- a/hosting/hosting-web-pages.md
+++ b/hosting/hosting-web-pages.md
@@ -44,7 +44,7 @@ Once you have your domain link, we can get to work linking it with your repl:
 4. Go to your domain registrar and find the section that allows you to add DNS records.
 5. Add a new entry with the following information:
 > * The type should be `CNAME`.
->* `name` or `hostname` will be the subdomain you want, or you can enter `@` if you'd like to use the full domain. Some services do not allow `CNAME`s to be at the top level. We recommend instead using _www_ and making sure you enter _www.yourdomain.com_ in your repl.
+>* `name` or `hostname` will be the subdomain you want, or you can enter `@` if you'd like to use the full domain. Some services do not allow `CNAME`s to be at the top level. We recommend instead using _www_ and making sure you enter `www.yourdomain.com` in your repl.
 >* `data` or `target` should be the special repl.co link you got when you started linking your repl. It should contain a long string of random numbers and letters at the beginning.
 
 For example:

--- a/programming-ide/installing-packages.md
+++ b/programming-ide/installing-packages.md
@@ -64,8 +64,8 @@ This will tell the packager that your project requires at least Python version 3
 
 ### JavaScript
 
-Note that `package.json` files are only for Nodejs/Express repls (they do not work in HTML/CSS/JS repls). A `package.json` file contains more information about the project, but also lists the dependencies. As an example, here is the `package.json` file included in our
-[express template](https://replit.com/languages/express):
+Note that `package.json` files are only for Nodejs/Express repls (they do not work in HTML/CSS/JS repls). A `package.json` file contains more information about the project, but also lists the dependencies. As an example, here is the `package.json` file you can include in a
+[Nodejs/Express template](https://replit.com/languages/nodejs):
 
 ```json
 {

--- a/teams/inviting-teachers-students.md
+++ b/teams/inviting-teachers-students.md
@@ -1,7 +1,7 @@
 # Inviting teachers and students
 
 
-To invite people with their Replit username or email address, follow the steps during [team creation](https://docs.replit.com/Teams/Intro). 
+To invite people with their Replit username or email address, follow the steps during [team creation](https://docs.replit.com/teams/intro-teams-education). 
 
 
 If you've already created a team, navigate to your [team dashboard](https://replit.com/teams), click on your chosen team username, and then click "Manage team members".

--- a/tutorials/01-introduction-to-the-repl-it-ide.md
+++ b/tutorials/01-introduction-to-the-repl-it-ide.md
@@ -134,7 +134,7 @@ What does this mean? Because no one else can edit your repl, you can share it fa
 
 Of course, sometimes you might _want_ others to have write access to your repl so that they can contribute, or help you out with a problem. In these cases, you can use Replit's "multiplayer" functionality.
 
-If you invite someone to your repl, it's different from sharing the URL with them. You can invite someone by clicking `Invite` in the top right and sending them the secret link that starts with "https://replit.com/join". This link will give people _edit_ access to your repl.
+If you invite someone to your repl, it's different from sharing the URL with them. You can invite someone by clicking `Invite` in the top right and sending them the secret link that starts with `https://replit.com/join`. This link will give people _edit_ access to your repl.
 
 ![**Image 11**: *Inviting someone to your repl*](/images/tutorials/01-introduction/01-11-multiplayer-invite.png)
 

--- a/tutorials/09-test-driven-development.md
+++ b/tutorials/09-test-driven-development.md
@@ -82,7 +82,7 @@ import pytest
 pytest.main()
 ```
 
-Press the `Run` button. `pytest` does automatic test discovery so you don't need to tell it which tests to run. It will look for files that start with `test` and for functions that start with `test_` and assume these are tests. (You can read more about exactly how test discovery works and can be configured [here](https://docs.pytest.org/en/reorganize-docs/new-docs/user/naming_conventions.html).)
+Press the `Run` button. `pytest` does automatic test discovery so you don't need to tell it which tests to run. It will look for files that start with `test` and for functions that start with `test_` and assume these are tests. (You can read more about exactly how test discovery works and can be configured [here](https://docs.pytest.org/en/6.2.x/getting-started.html).)
 
 You should see some scary looking red failures, as shown below. (`pytest` uses dividers such as `======` and `------` to format sections and these can get messy if your output pane is too narrow. If things look a bit wonky try making it wider and rerunning.)
 

--- a/tutorials/18-telegram-bot.md
+++ b/tutorials/18-telegram-bot.md
@@ -223,9 +223,9 @@ def home(page=None):
 
 This defines a small Flask app. Replit takes care of our Flask import. For this tutorial, we'll only make a single page.
 
-We tell Flask how the page should be reachable with special decorators. `@app.route('/')` says that when the user accesses at https://example.com, it will serve this handler. In this case, the variable "page" will default to None.
+We tell Flask how the page should be reachable with special decorators. `@app.route('/')` says that when the user accesses at `https://example.com`, it will serve this handler. In this case, the variable "page" will default to None.
 
-`@app.route('/<int:page>')` says that when a user accesses something like https://example.com/4 then it will open to page 4 of the logged messages. In this case, the variable "page" will be set to 4.
+`@app.route('/<int:page>')` says that when a user accesses something like `https://example.com/4` then it will open to page 4 of the logged messages. In this case, the variable "page" will be set to 4.
 
 This won't work yet, because our template `home.html` doesn't exist. Let's create that now in a folder called "templates" (i.e. templates/home.html):
 

--- a/tutorials/21-build-snake-with-kaboom.md
+++ b/tutorials/21-build-snake-with-kaboom.md
@@ -43,7 +43,7 @@ Using Kaboom.js in Replit takes care of all the boilerplate initialisation code,
 
 To start, we can get our game board, or _map_ drawn on the screen. This will define the edges of the board so that if the snake crashes into them, we can detect and end the game.
 
-Kaboom.js has built-in support for defining game maps, using a text array and the function [`addLevel`](https://kaboomjs.com/#addLevel). This takes away a lot of the hassle normally involved in loading and rendering maps. 
+Kaboom.js has built-in support for defining game maps, using a text array and the function [`addLevel`](https://kaboomjs.com/doc#addLevel). This takes away a lot of the hassle normally involved in loading and rendering maps. 
 
 Add this code to the `main.js` file to create the game board:
 
@@ -148,13 +148,13 @@ respawn_all();
 
 ```
 
-First, the function gets rid of any existing snake segment objects by using the Kaboom.js [`destroyAll` function](https://kaboomjs.com/#destroyAll). This removes any object with the given tag from the game. Then we reset our segment array to an empty array, and the snake length back to the default. 
+First, the function gets rid of any existing snake segment objects by using the Kaboom.js [`destroyAll` function](https://kaboomjs.com/doc#destroyAll). This removes any object with the given tag from the game. Then we reset our segment array to an empty array, and the snake length back to the default. 
 
-Then the function sets up a loop to create new snake segments, up to the length we specified. It does this by calling the Kaboom.js [`add`](https://kaboomjs.com/#add) method, which adds a new object to the game. `add` takes a few parameters, as components of the object to create. We pass in components to specify how to draw the object (using [`rect`](https://kaboomjs.com/#rect)), its color, and a tag "snake" to identify the segments when we are checking collisions, and updating/removing segments. We also specify the position for the segment we create. To create the starting snake, we just ensure it is at least one `block_size`, or block, from the left side, and then add each subsequent segment one more block down per loop. This gives a straight snake pointing down to start. Then we add the new segment to our `snake_body` array to keep track of it. 
+Then the function sets up a loop to create new snake segments, up to the length we specified. It does this by calling the Kaboom.js [`add`](https://kaboomjs.com/doc#add) method, which adds a new object to the game. `add` takes a few parameters, as components of the object to create. We pass in components to specify how to draw the object (using [`rect`](https://kaboomjs.com/doc#rect)), its color, and a tag "snake" to identify the segments when we are checking collisions, and updating/removing segments. We also specify the position for the segment we create. To create the starting snake, we just ensure it is at least one `block_size`, or block, from the left side, and then add each subsequent segment one more block down per loop. This gives a straight snake pointing down to start. Then we add the new segment to our `snake_body` array to keep track of it. 
 
 Finally, we set a default starting direction for the snake to move in. 
 
-You'll notice that we also add in a function `respawn_all`, and a call to the function `respawn_snake`. We'll use the `respawn_all` function to call all of our other respawn functions. Currently we have one for the snake, but we'll also need one for the food when we add it. In the `respawn_all` function, we also take care to set the `run_loop` flag to false, so that no updates are made while we are setting up or resetting objects. We also wrap the calls in a Kaboom.js [`wait` function](https://kaboomjs.com/#wait), with a small delay of 0.5 seconds. This is because when we detect a "game over" condition, we don't immediately want to reset the game, as it could be a bit disorienting to a player. 
+You'll notice that we also add in a function `respawn_all`, and a call to the function `respawn_snake`. We'll use the `respawn_all` function to call all of our other respawn functions. Currently we have one for the snake, but we'll also need one for the food when we add it. In the `respawn_all` function, we also take care to set the `run_loop` flag to false, so that no updates are made while we are setting up or resetting objects. We also wrap the calls in a Kaboom.js [`wait` function](https://kaboomjs.com/doc#wait), with a small delay of 0.5 seconds. This is because when we detect a "game over" condition, we don't immediately want to reset the game, as it could be a bit disorienting to a player. 
 
 Running the code now, you should see a blue line at the top-left side of the map. 
 
@@ -165,7 +165,7 @@ Running the code now, you should see a blue line at the top-left side of the map
 
 Now that we've got map boundaries, and a snake drawn on the screen, we can work on getting player input and moving the snake around. 
 
-Kaboom.js has a function [`keypress`](https://kaboomjs.com/#keyPress), which can call a supplied function whenever a particular key is pressed. We'll use that to determine which way the player wants the snake to go. Add this code to get user direction input: 
+Kaboom.js has a function [`keypress`](https://kaboomjs.com/doc#keyPress), which can call a supplied function whenever a particular key is pressed. We'll use that to determine which way the player wants the snake to go. Add this code to get user direction input: 
 
 ```javascript
 keyPress("up", () => {
@@ -196,7 +196,7 @@ keyPress("right", () => {
 
 For each of the named "arrow" keys, we set up a function to call if the key is pressed. In each of these functions, we check to ensure that the new direction input is not the complete opposite direction to which the snake is currently moving. This is because we don't want to allow the snake to reverse. If the input direction is a legal move, we update the `current_direction` property to the new direction. 
 
-Now we need to think about how to make the snake appear to move on the screen. A way to do this is to check which direction the snake is heading, and add a block in front of the snake in that direction. Then we'll need to remove a block at the tail-end of the snake. We'll need to do this a few times in a second so that the snake appears to be moving smoothly. Kaboom.js has a function [`loop`](https://kaboomjs.com/#loop) which can call a given function at a regular interval that we specify. Add the following code, which uses the `loop` function, to move the snake: 
+Now we need to think about how to make the snake appear to move on the screen. A way to do this is to check which direction the snake is heading, and add a block in front of the snake in that direction. Then we'll need to remove a block at the tail-end of the snake. We'll need to do this a few times in a second so that the snake appears to be moving smoothly. Kaboom.js has a function [`loop`](https://kaboomjs.com/doc#loop) which can call a given function at a regular interval that we specify. Add the following code, which uses the `loop` function, to move the snake: 
 
 ```javascript
 
@@ -250,7 +250,7 @@ Then the function switches on the value of the current direction the snake is he
 
 After the switch, we get the current snake head by indexing the last element in the snake body array. Now that we have both the current snake head position, and the position amount relative to the snake head to move in, we can create the new snake head by adding a new block game object. This is similar to the code we used in `respawn_snake`. 
 
-Now all that remains is to remove a block at the tail end of the snake, using the built-in array [`shift` function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/shift), which removes the first element from an array, and returns that element. Because our 'oldest' part of the snake, also known as a tail, is the first element, we call shift on the array, and then the Kaboom.js [`destroy` function](https://kaboomjs.com/#destroy) to get rid of the segment. We only do this if the current length of the snake body array is greater than our determined snake length. This means if we increase `snake_length`, the overall length of the snake on the screen will also increase. We can use this when we add food to the game. 
+Now all that remains is to remove a block at the tail end of the snake, using the built-in array [`shift` function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/shift), which removes the first element from an array, and returns that element. Because our 'oldest' part of the snake, also known as a tail, is the first element, we call shift on the array, and then the Kaboom.js [`destroy` function](https://kaboomjs.com/doc#destroy) to get rid of the segment. We only do this if the current length of the snake body array is greater than our determined snake length. This means if we increase `snake_length`, the overall length of the snake on the screen will also increase. We can use this when we add food to the game. 
 
 Running the project now and clicking into the game screen should allow you to move the snake around. Note that there isn't collision detection yet, so the snake can go out of bounds without consequence. 
 
@@ -285,11 +285,11 @@ function respawn_food(){
 
 Firstly, we set up a variable `food` so that we can keep track of food objects we create. You can move this variable up to where we declared other variables, like `block_size` and `snake_body` if you want to keep them all neatly in the same place.
 
-Then the function `respawn_food` does a few things. In the game of snake, once a food block is eaten, another one appears at a random location on the grid. This means we'll need a random number generator to determine the location to place the food. Kaboom.js has a function called [`rand`](https://kaboomjs.com/#rand) which we can use to find a random position on the screen to place the food. We need both random `x` and `y` co-ordinates – conveniently, the `rand` function can accept 2D vectors as the start and end amount for the random range to generate numbers in, and will then return another 2D vector as a result. 
+Then the function `respawn_food` does a few things. In the game of snake, once a food block is eaten, another one appears at a random location on the grid. This means we'll need a random number generator to determine the location to place the food. Kaboom.js has a function called [`rand`](https://kaboomjs.com/doc#rand) which we can use to find a random position on the screen to place the food. We need both random `x` and `y` co-ordinates – conveniently, the `rand` function can accept 2D vectors as the start and end amount for the random range to generate numbers in, and will then return another 2D vector as a result. 
 
-Why do we choose a range of 1-13 for the random position of the food? If you look at the map we added earlier, it is 14 spaces across and 14 spaces down. These are the dimensions of our screen in grid blocks. Because we don't want to draw the food over the boundaries, we use 1-13 to choose blocks within the map. Now, the `rand` function returns real numbers, with decimals, not integers. This means we need to add the `Math.floor` call to truncate any decimals off the random numbers, as we don't want to place the food halfway through a particular grid block. We also need to convert from our grid co-ordinates to regular screen pixels. This is done by multiplying each co-ordinate by the `block_size`, which specifies the size of each grid block in pixels. We make use of the Kaboom.js [`scale` method](https://kaboomjs.com/#vec2) on the `vec2` class to perform the multiplication. 
+Why do we choose a range of 1-13 for the random position of the food? If you look at the map we added earlier, it is 14 spaces across and 14 spaces down. These are the dimensions of our screen in grid blocks. Because we don't want to draw the food over the boundaries, we use 1-13 to choose blocks within the map. Now, the `rand` function returns real numbers, with decimals, not integers. This means we need to add the `Math.floor` call to truncate any decimals off the random numbers, as we don't want to place the food halfway through a particular grid block. We also need to convert from our grid co-ordinates to regular screen pixels. This is done by multiplying each co-ordinate by the `block_size`, which specifies the size of each grid block in pixels. We make use of the Kaboom.js [`scale` method](https://kaboomjs.com/doc#vec2) on the `vec2` class to perform the multiplication. 
 
-The next part of the function checks if the `food` variable already contains an existing food object. If it does, we call [`destroy`](https://kaboomjs.com/#destroy) to remove that food from the game. Finally, the function creates a new food object by calling the Kaboom.js [`add`](https://kaboomjs.com/#add) function to create a new food object at the random position we made.  
+The next part of the function checks if the `food` variable already contains an existing food object. If it does, we call [`destroy`](https://kaboomjs.com/doc#destroy) to remove that food from the game. Finally, the function creates a new food object by calling the Kaboom.js [`add`](https://kaboomjs.com/doc#add) function to create a new food object at the random position we made.  
 
 To call this new `respawn_food` function, we need to update our `respawn_all` function, like this:
 
@@ -312,7 +312,7 @@ Running the game now shows a green food block positioned somewhere randomly on t
 
 Now that we have all the objects our game needs – a boundary wall, a snake, and food – we can move on to detecting interactions, or collisions, between these objects. 
 
-Kaboom.js has 2 useful functions for helping with this: [`collides`](https://kaboomjs.com/#collides) and [`overlaps`](https://kaboomjs.com/#overlaps). They both take in 2 tags for different game object types, and call a provided callback function if there is a collision of the objects. The big difference is that `collides` will call our given function even if just the edges of the game objects touch, whereas `overlaps` means that the game objects must be more than touching, there must be at least 1 pixel overlap, before firing the callback function. 
+Kaboom.js has 2 useful functions for helping with this: [`collides`](https://kaboomjs.com/doc#collides) and [`overlaps`](https://kaboomjs.com/doc#overlaps). They both take in 2 tags for different game object types, and call a provided callback function if there is a collision of the objects. The big difference is that `collides` will call our given function even if just the edges of the game objects touch, whereas `overlaps` means that the game objects must be more than touching, there must be at least 1 pixel overlap, before firing the callback function. 
 
 We'll use `overlaps` here, as we don't want the game to end just by the snake merely brushing against the boundary wall for example.
 
@@ -341,7 +341,7 @@ overlaps("snake", "wall", (s, w) => {
     respawn_all(); 
 });
 ```
-In the callback function, we immediately set the `run_loop` flag to false. This is so that the code in the move loop does not run and create the appearance of the snake stuck in the wall. Then the code calls a cool Kaboom.js effect function [`camShake`](https://kaboomjs.com/#camShake), which "shakes" the screen in a way that makes it feel like the snake has crashed heavily, and communicates quite effectively that the game is over. Finally, we call `respawn_all` to reset all the game objects. 
+In the callback function, we immediately set the `run_loop` flag to false. This is so that the code in the move loop does not run and create the appearance of the snake stuck in the wall. Then the code calls a cool Kaboom.js effect function [`camShake`](https://kaboomjs.com/doc#camShake), which "shakes" the screen in a way that makes it feel like the snake has crashed heavily, and communicates quite effectively that the game is over. Finally, we call `respawn_all` to reset all the game objects. 
 
 We can use the same code to detect if the snake has hit itself – we just replace the `wall` tag with another `snake` tag: 
 
@@ -395,7 +395,7 @@ function respawn_food(){
 }
 ```
 
-We can also update the background to be more interesting. To do this, we can make use of Kaboom.js' [layers](https://kaboomjs.com/#layers) concept. This allows us to create different graphic layers, for example one for a static background image, another one for the active game objects over that, and another top layer for stats and scores etc. 
+We can also update the background to be more interesting. To do this, we can make use of Kaboom.js' [layers](https://kaboomjs.com/doc#layers) concept. This allows us to create different graphic layers, for example one for a static background image, another one for the active game objects over that, and another top layer for stats and scores etc. 
 
 We'll create 2 layers, background and game, to support a background. Download and add the background grass image below to your repl as you did for the pizza slice:
 
@@ -416,9 +416,9 @@ add([
 
 ```
 
-This sets up our 2 layers, and makes the `game` layer the default layer to draw on. Whenever we call [`add`](https://kaboomjs.com/#add), we can optionally specify a layer to put the object on – if we don't specify a layer, it uses whatever we set as default in the call to [`layers`](https://kaboomjs.com/#layers). Then we add our background sprite to the background layer. 
+This sets up our 2 layers, and makes the `game` layer the default layer to draw on. Whenever we call [`add`](https://kaboomjs.com/doc#add), we can optionally specify a layer to put the object on – if we don't specify a layer, it uses whatever we set as default in the call to [`layers`](https://kaboomjs.com/doc#layers). Then we add our background sprite to the background layer. 
 
-Next, we can update the boundaries to look a bit better. Recall that in our map we add with [`addLevel`](https://kaboomjs.com/#addLevel), each different symbol we use can map to a different game object. Using this, we can create a good looking border fence, with different elements for each side and corners. Download the following 8 sprites as before, and upload them to your repl:
+Next, we can update the boundaries to look a bit better. Recall that in our map we add with [`addLevel`](https://kaboomjs.com/doc#addLevel), each different symbol we use can map to a different game object. Using this, we can create a good looking border fence, with different elements for each side and corners. Download the following 8 sprites as before, and upload them to your repl:
 
 <img src="/images/tutorials/21-snake-kaboom/fence-bottom.png"
      alt="fence bottom"
@@ -561,7 +561,7 @@ There is a lot of good functionality in [Kaboom.js](https://kaboomjs.com/) to tr
 - Create a 2 player version.
 - Add obstacles for the snake.
 - Incrementally speed up the game as it goes on, to make it harder. You can do this by adjusting the delay parameter of the `loop` function as the game progresses. 
-- Add [sound effects](https://kaboomjs.com/#play) and background music.
+- Add [sound effects](https://kaboomjs.com/doc#play) and background music.
 
 
 <iframe height="400px" width="100%" src="https://replit.com/@ritza/Snake?lite=true" scrolling="no" frameborder="no" allowtransparency="true" allowfullscreen="true" sandbox="allow-forms allow-pointer-lock allow-popups allow-same-origin allow-scripts allow-modals"></iframe>

--- a/tutorials/23-build-asteroids-with-kaboom.md
+++ b/tutorials/23-build-asteroids-with-kaboom.md
@@ -79,7 +79,7 @@ ui = add([
 ]);
 ```
 
-Although Kaboom allows us to [create objects that display text](https://kaboomjs.com/#text), this text is set once at object creation and has to be updated manually, which doesn't really make sense for a real-time UI. Instead of doing that, we'll use our `ui` object's [draw event](https://kaboomjs.com/#on) [callback](https://en.wikipedia.org/wiki/Callback_(computer_programming)) to draw text containing the current score. Add the following code:
+Although Kaboom allows us to [create objects that display text](https://kaboomjs.com/doc#text), this text is set once at object creation and has to be updated manually, which doesn't really make sense for a real-time UI. Instead of doing that, we'll use our `ui` object's [draw event](https://kaboomjs.com/doc#on) [callback](https://en.wikipedia.org/wiki/Callback_(computer_programming)) to draw text containing the current score. Add the following code:
 
 ```javascript
 ui.on("draw", () => {
@@ -126,12 +126,12 @@ const player = add([
 ]);
 ```
 
-Here we're creating a game object with a number of [components](https://kaboomjs.com/#readd), each of which give our object some data or behavior. These are:
+Here we're creating a game object with a number of [components](https://kaboomjs.com/doc#readd), each of which give our object some data or behavior. These are:
 
-* The [`sprite`](https://kaboomjs.com/#sprite) component, which draws the `ship.png` sprite.
-* The [`pos`](https://kaboomjs.com/#pos) (position) component, which places the player near the center of the screen in the Replit browser.
-* The [`rotate`](https://kaboomjs.com/#rotate) component, which will allow the player to turn the ship with the left and right arrow keys.
-* The [`origin`](https://kaboomjs.com/#origin) component, which sets the sprite's *origin* to "center", so that when we rotate the ship, it will rotate around the middle of its sprite rather than the default top-left corner.
+* The [`sprite`](https://kaboomjs.com/doc#sprite) component, which draws the `ship.png` sprite.
+* The [`pos`](https://kaboomjs.com/doc#pos) (position) component, which places the player near the center of the screen in the Replit browser.
+* The [`rotate`](https://kaboomjs.com/doc#rotate) component, which will allow the player to turn the ship with the left and right arrow keys.
+* The [`origin`](https://kaboomjs.com/doc#origin) component, which sets the sprite's *origin* to "center", so that when we rotate the ship, it will rotate around the middle of its sprite rather than the default top-left corner.
 
 Following that initial configuration, we're giving the player object three tags: `player`, `mobile` and `wraps`. Kaboom uses a tagging system to apply behavior to objects -- you can think of this as similar to [multiple inheritance](https://en.wikipedia.org/wiki/Multiple_inheritance). By tagging objects with shared behavior, we can save ourselves from duplicating code.
 
@@ -171,7 +171,7 @@ keyDown("up", () => {
 
 Rather than having the spaceship go from zero to max speed immediately, we want to simulate a gradual acceleration to our max speed. To achieve this, we use [Math.min()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/min) to set the player's speed to the minimum value between current speed plus acceleration and its maximum speed. This will make the ship gradually increase in speed until it reaches `max_thrust`. Play around with the values of `acceleration` and `max_thrust` in the player creation code and see what feels right to you.
 
-Additionally, we set our rocket thrust sound to [play](https://kaboomjs.com/#play) while accelerating. Kaboom allows us to manipulate sounds in a few different ways, such as changing their speed and volume.
+Additionally, we set our rocket thrust sound to [play](https://kaboomjs.com/doc#play) while accelerating. Kaboom allows us to manipulate sounds in a few different ways, such as changing their speed and volume.
 
 We'll handle deceleration by doing the opposite to acceleration, using [Math.max()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/max) to choose the maximum between the player's speed minus their deceleration, and their maximum speed in reverse (i.e. negative). Add the following code below the acceleration controls:
 
@@ -201,9 +201,9 @@ action("mobile", (e) => {
 });    
 ```
 
-First, we move our object, using the function `pointAt()`, which takes a speed and an angle and returns the corresponding X and Y co-ordinates as a [`vec2`](https://kaboomjs.com/#vec2) object, Kaboom's 2D vector type. This data type is provided by Kaboom specifically for working with X and Y coordinates, and comes with a number of useful functions, such as addition and subtraction.
+First, we move our object, using the function `pointAt()`, which takes a speed and an angle and returns the corresponding X and Y co-ordinates as a [`vec2`](https://kaboomjs.com/doc#vec2) object, Kaboom's 2D vector type. This data type is provided by Kaboom specifically for working with X and Y coordinates, and comes with a number of useful functions, such as addition and subtraction.
 
-After moving, we invoke Kaboom's [`resolve()`](https://kaboomjs.com/#solid) method, which is necessary to determine collisions with solid objects. This will become relevant later on, when we create our asteroids.
+After moving, we invoke Kaboom's [`resolve()`](https://kaboomjs.com/doc#solid) method, which is necessary to determine collisions with solid objects. This will become relevant later on, when we create our asteroids.
 
 Now we need to create the `pointAt()` function. Before we jump into the code, let's think about the problem. Our movement can be drawn as an angled line on a plane, and its X and Y coordinates as horizontal and vertical lines connected to it, giving us a right-angled triangle.
 
@@ -251,7 +251,7 @@ action("wraps", (e) => {
 });
 ```
 
-This is a fairly straightforward piece of code that checks whether an object's position is outside of the room and, if so, places it on the other side. The [`width()`](https://kaboomjs.com/#width) and [`height()`](https://kaboomjs.com/#height) functions are Kaboom built-ins that return the size of the game canvas. Run your repl now and try it out.
+This is a fairly straightforward piece of code that checks whether an object's position is outside of the room and, if so, places it on the other side. The [`width()`](https://kaboomjs.com/doc#width) and [`height()`](https://kaboomjs.com/doc#height) functions are Kaboom built-ins that return the size of the game canvas. Run your repl now and try it out.
 
 ### Rocket animation
 
@@ -266,7 +266,7 @@ First, let's create an array with our four rocket sprites. Add the following cod
 const thrust_animation = ["rocket1", "rocket2", "rocket3", "rocket4"];
 ```
 
-Then we need some way to indicate when to start and stop the animation. We can use Kaboom's [`keyPress`](https://kaboomjs.com/#keyPress) and [`keyRelease`](https://kaboomjs.com/#keyRelease) events for this, as well as two of the properties we defined for our player (`thrusting` and `animation_frame`). Add the following code:
+Then we need some way to indicate when to start and stop the animation. We can use Kaboom's [`keyPress`](https://kaboomjs.com/doc#keyPress) and [`keyRelease`](https://kaboomjs.com/doc#keyRelease) events for this, as well as two of the properties we defined for our player (`thrusting` and `animation_frame`). Add the following code:
 
 ```javascript
 // rocket animation helpers
@@ -297,7 +297,7 @@ on("draw", "player", (p) => {
 
 Here we're using our `pointAt` function again, but this time we're looking for the rocket end of the ship, rather than its nose. We use our `thrust_animation` array in conjunction with the player's `animation_frame` value to figure out which rocket image to draw.
 
-To actually make the rocket animate (i.e. cycle through animation frames), we'll use Kaboom's [`loop`](https://kaboomjs.com/#loop) timer, and create a callback that changes the animation frame every 0.1 seconds. Add the following code:
+To actually make the rocket animate (i.e. cycle through animation frames), we'll use Kaboom's [`loop`](https://kaboomjs.com/doc#loop) timer, and create a callback that changes the animation frame every 0.1 seconds. Add the following code:
 
 ```javascript
 // loop rocket animation
@@ -371,7 +371,7 @@ keyDown("space", () => {
 });
 ```
 
-Here, we use two of the properties we defined in the player object above, `can_shoot` and `laser_cooldown`, to implement a cooldown mechanism. We will only create a bullet if `can_shoot` is true, and we set it to false immediately after each shot. Then we use Kaboom's [`wait`](https://kaboomjs.com/#wait) timer to set it to true after `laser_cooldown` number of seconds. Because this timer is an [asynchronous callback](https://en.wikipedia.org/wiki/Callback_(computer_programming)), the rest of the game can continue while the laser cooldown period passes.
+Here, we use two of the properties we defined in the player object above, `can_shoot` and `laser_cooldown`, to implement a cooldown mechanism. We will only create a bullet if `can_shoot` is true, and we set it to false immediately after each shot. Then we use Kaboom's [`wait`](https://kaboomjs.com/doc#wait) timer to set it to true after `laser_cooldown` number of seconds. Because this timer is an [asynchronous callback](https://en.wikipedia.org/wiki/Callback_(computer_programming)), the rest of the game can continue while the laser cooldown period passes.
 
 Run your repl and test whether the ship's laser fires at the expected intervals.
 
@@ -410,7 +410,7 @@ for (let i = 0; i < NUM_ASTERIODS; i++) {
 }
 ```
 
-Here we're creating a constant number of asteroids, and assigning them a random position, direction of movement and speed. The asteroid creation code is largely similar to our player creation code, but with fewer custom properties. One key difference is the presence of the [`solid`](https://kaboomjs.com/#solid) component, which marks the asteroid as a solid object that other objects shouldn't be able to pass through. This is supported by the `resolve()` call we added in our movement code above.
+Here we're creating a constant number of asteroids, and assigning them a random position, direction of movement and speed. The asteroid creation code is largely similar to our player creation code, but with fewer custom properties. One key difference is the presence of the [`solid`](https://kaboomjs.com/doc#solid) component, which marks the asteroid as a solid object that other objects shouldn't be able to pass through. This is supported by the `resolve()` call we added in our movement code above.
 
 The one custom property that's unique to asteroids is `initializing`. Because we're spawning each asteroid in a random position, there's a chance we might spawn one on top of another, or on top of the player.
 
@@ -442,7 +442,7 @@ function asteroidSpawnPoint() {
 }
 ```
 
-This function uses Kaboom's [`choose()`](https://kaboomjs.com/#choose) and [`rand()`](https://kaboomjs.com/#rand) functions to choose a random location on the edge of the scene to spawn an asteroid.
+This function uses Kaboom's [`choose()`](https://kaboomjs.com/doc#choose) and [`rand()`](https://kaboomjs.com/doc#rand) functions to choose a random location on the edge of the scene to spawn an asteroid.
 
 ### Collisions
 
@@ -501,7 +501,7 @@ Run the game now and see what happens when you ram your ship into some asteroids
 
 ## Ending the game
 
-The player's ship can now lose lives by crashing into asteroids, but this doesn't mean much at the moment, as we haven't added any code to end the game if the player runs out of lives, or even to display the lives remaining. Let's do that now. First, let's change the code in the player–asteroid collision to [trigger](https://kaboomjs.com/#obj.trigger) a custom "damage" event instead of just subtracting a life.
+The player's ship can now lose lives by crashing into asteroids, but this doesn't mean much at the moment, as we haven't added any code to end the game if the player runs out of lives, or even to display the lives remaining. Let's do that now. First, let's change the code in the player–asteroid collision to [trigger](https://kaboomjs.com/doc#obj.trigger) a custom "damage" event instead of just subtracting a life.
 
 ```javascript
 // Collisions
@@ -595,7 +595,7 @@ const music = play("Steamtech-Mayhem_Looping");
 music.loop();
 ```
 
-The first line [plays](https://kaboomjs.com/#play) the piece [Steamtech Mayhem from Soundimage.org](https://soundimage.org/sci-fi/) and the second line will ensure that it repeats as long as the game is running.
+The first line [plays](https://kaboomjs.com/doc#play) the piece [Steamtech Mayhem from Soundimage.org](https://soundimage.org/sci-fi/) and the second line will ensure that it repeats as long as the game is running.
 
 ### Smaller asteroids
 
@@ -680,7 +680,7 @@ player.on("damage", () => {
 });
 ```
 
-Here we're making the player invulnerable and then using a `wait` callback to make them vulnerable again after a given number of seconds, similar to what we did for the laser timeout. We're also making sure the player is visible by setting [`player.hidden`](https://kaboomjs.com/#add) to false, because the way we're going to indicate the player's invulnerability is by having their ship flash rapidly. Add the following `loop` timer just below the above code:
+Here we're making the player invulnerable and then using a `wait` callback to make them vulnerable again after a given number of seconds, similar to what we did for the laser timeout. We're also making sure the player is visible by setting [`player.hidden`](https://kaboomjs.com/doc#add) to false, because the way we're going to indicate the player's invulnerability is by having their ship flash rapidly. Add the following `loop` timer just below the above code:
 
 ```javascript
 loop(0.1, () => {

--- a/tutorials/24-build-space-shooter-with-kaboom.md
+++ b/tutorials/24-build-space-shooter-with-kaboom.md
@@ -66,7 +66,7 @@ The sprite `stars` refers to an image in the Sprites folder.
 
 Let's get a scene layout, or _map_, drawn on the screen. This will define the ground and platforms in the game.
 
-Kaboom has built-in support for defining game maps using text and the function [`addLevel`](https://kaboomjs.com/#addLevel). This takes away a lot of the hassle normally involved in loading and rendering maps. 
+Kaboom has built-in support for defining game maps using text and the function [`addLevel`](https://kaboomjs.com/doc#addLevel). This takes away a lot of the hassle normally involved in loading and rendering maps. 
 
 
 Add the code below to the `main.js` file to create the game map:
@@ -145,7 +145,7 @@ If we run the code, we should see the game map, like this:
 
 ## Adding the Spaceship
 
-Let's add the spaceship using the [`add`](https://kaboomjs.com/#add) function:
+Let's add the spaceship using the [`add`](https://kaboomjs.com/doc#add) function:
 
 ```javascript
 const player = add([
@@ -169,13 +169,13 @@ player.action(() => {
 
 ```
 
-The [`add`](https://kaboomjs.com/#add) function constructs a game object using different components, e.g. `pos`, `body`, `scale`, etc. Each of these components gives the object different features. 
+The [`add`](https://kaboomjs.com/doc#add) function constructs a game object using different components, e.g. `pos`, `body`, `scale`, etc. Each of these components gives the object different features. 
 
-Notably, the [`body`](https://kaboomjs.com/#body) component makes the object react to gravity: the spaceship falls if it's not on the ground or a platform. The [`rotate`](https://kaboomjs.com/#rotate) component allows us to tilt the spaceship in the direction the player wants to go, providing good visual feedback. By default, all operations are calculated around the top left corner of game objects. To make the tilt work correctly, we add the [`origin`](https://kaboomjs.com/#origin) component and set it to `center`, so that the tilt adjusts the angle from the center of the object. 
+Notably, the [`body`](https://kaboomjs.com/doc#body) component makes the object react to gravity: the spaceship falls if it's not on the ground or a platform. The [`rotate`](https://kaboomjs.com/doc#rotate) component allows us to tilt the spaceship in the direction the player wants to go, providing good visual feedback. By default, all operations are calculated around the top left corner of game objects. To make the tilt work correctly, we add the [`origin`](https://kaboomjs.com/doc#origin) component and set it to `center`, so that the tilt adjusts the angle from the center of the object. 
 
 Kaboom also allows us to attach custom data to a game object. We've added `score` to hold the player's latest score, and `shield` to hold the percentage of the ship's protection shield still available. We can adjust these as the player picks up items or crashes into aliens. 
 
-When we created the `map` earlier, we added the [`solid`](https://kaboomjs.com/#solid) component to map objects. This component marks objects as solid, meaning other objects can't move past them. If we add `solid` to an object, we also need to add code to resolve the position of movable objects that might be obstructed by these solid objects. We did this by adding the `player.resolve()` call in the [`action`](https://kaboomjs.com/#action) event of the player, or spaceship. 
+When we created the `map` earlier, we added the [`solid`](https://kaboomjs.com/doc#solid) component to map objects. This component marks objects as solid, meaning other objects can't move past them. If we add `solid` to an object, we also need to add code to resolve the position of movable objects that might be obstructed by these solid objects. We did this by adding the `player.resolve()` call in the [`action`](https://kaboomjs.com/doc#action) event of the player, or spaceship. 
 
 
 ## Moving the Spaceship
@@ -219,7 +219,7 @@ keyRelease("right", ()=>{
 
 First, we create a constant object defining the directions our game allows. Then we create a variable to track the `current_direction` the spaceship is facing.
 
-Then we add the key-handling code. The key names `left` and `right` refer to the left and right arrow keys on the keyboard. Kaboom provides the [`keyDown`](https://kaboomjs.com/#keyDown) event, which lets us know if a certain key is being pressed. We create `keyDown` event handlers for each of the arrow keys. As long as the given key is held down, `keyDown` calls the event handler repeatedly. 
+Then we add the key-handling code. The key names `left` and `right` refer to the left and right arrow keys on the keyboard. Kaboom provides the [`keyDown`](https://kaboomjs.com/doc#keyDown) event, which lets us know if a certain key is being pressed. We create `keyDown` event handlers for each of the arrow keys. As long as the given key is held down, `keyDown` calls the event handler repeatedly. 
 
 The code inside each `keyDown` event does the following: 
 - The `flipX` function mirrors the player's spaceship image so that it looks different depending on the direction it is facing. We use `-1` to flip it to appear facing the left, `1` the right. 
@@ -229,7 +229,7 @@ The code inside each `keyDown` event does the following:
 
 We also have `keyRelease` event handlers for the left and right keys. These reset the spaceship's tilt angle to 0 (i.e. straight up) when the ship is no longer moving in that direction. 
 
-Now we want to have the spaceship fly up when we press the `up arrow` key. To do this, we'll take advantage of Kaboom's [`jump`](https://kaboomjs.com/#body) attribute (which is part of the [`body`](https://kaboomjs.com/#body) component) and repurpose it for flying up. Add the following code to the main scene:
+Now we want to have the spaceship fly up when we press the `up arrow` key. To do this, we'll take advantage of Kaboom's [`jump`](https://kaboomjs.com/doc#body) attribute (which is part of the [`body`](https://kaboomjs.com/doc#body) component) and repurpose it for flying up. Add the following code to the main scene:
 
 ```javascript
 keyDown("up", () => {
@@ -273,15 +273,15 @@ function spawnBullet(bulletpos) {
 };
 ```
 
-First, we add a constant `BULLET_SPEED` to define the speed at which the laser "bullets" fly across the screen. Then we use the [`keyPress`](https://kaboomjs.com/#keyPress) event to trigger the shooting. Notice `keyPress` only calls the event handler once as the key is pressed, unlike the `keyDown` event we used for moving. This is because it's more fun if the player needs to bash the "fire" button as fast as possible to take down an enemy, rather than just having automatic weapons. 
+First, we add a constant `BULLET_SPEED` to define the speed at which the laser "bullets" fly across the screen. Then we use the [`keyPress`](https://kaboomjs.com/doc#keyPress) event to trigger the shooting. Notice `keyPress` only calls the event handler once as the key is pressed, unlike the `keyDown` event we used for moving. This is because it's more fun if the player needs to bash the "fire" button as fast as possible to take down an enemy, rather than just having automatic weapons. 
 
 The `keyPress` handler calls the `spawnBullet` function with the player's current position. This function handles creating a new laser shot in the correct direction. The first few lines of the method adjust the bullet's starting position a little to the left or right of the spaceship's position. This is because the position of the spaceship that gets passed to the function is the center of the spaceship (remember the `origin` component we added to it earlier). We adjust it a little so that the bullet looks like it is coming from the edge of the spaceship.
 
-Then we add a new bullet object to the game using the [`add`](https://kaboomjs.com/#add) function. We don't use a sprite for the bullet, but draw a [`rect`](https://kaboomjs.com/#rect), or rectangle, with our given color. We tag it `bullet` so we can refer to it later when detecting if it hit something. We also give it a custom property, `bulletSpeed`, which is the distance and direction we want the bullet to move on each frame. 
+Then we add a new bullet object to the game using the [`add`](https://kaboomjs.com/doc#add) function. We don't use a sprite for the bullet, but draw a [`rect`](https://kaboomjs.com/doc#rect), or rectangle, with our given color. We tag it `bullet` so we can refer to it later when detecting if it hit something. We also give it a custom property, `bulletSpeed`, which is the distance and direction we want the bullet to move on each frame. 
 
-Finally, we add sound effects when the player shoots. The [`play`](https://kaboomjs.com/#play) function plays our "shoot.wav" file. We adjust the volume down a bit, so it fits in better with the overall sound mix. We use the `detune` parameter along with a random number generator, [`rand`]('https://kaboomjs.com/#rand'), to change the pitch of the sound each time it's played. This is so the sound doesn't become too repetitive and also because it sounds weird and "spacey". 
+Finally, we add sound effects when the player shoots. The [`play`](https://kaboomjs.com/doc#play) function plays our "shoot.wav" file. We adjust the volume down a bit, so it fits in better with the overall sound mix. We use the `detune` parameter along with a random number generator, [`rand`]('https://kaboomjs.com/doc#rand'), to change the pitch of the sound each time it's played. This is so the sound doesn't become too repetitive and also because it sounds weird and "spacey". 
 
-Now that we've set up the bullet, we need to make it move on each frame. To do this we can use the [`action`](https://kaboomjs.com/#action) event, using the `bullet` tag to identify the objects we want to update:
+Now that we've set up the bullet, we need to make it move on each frame. To do this we can use the [`action`](https://kaboomjs.com/doc#action) event, using the `bullet` tag to identify the objects we want to update:
 
 ```javascript
 action("bullet", (b) => {
@@ -292,9 +292,9 @@ action("bullet", (b) => {
 });
 ```
 
-With each frame, the action event updates the objects with the matching tag, in this case `bullet`. We call [`move`](https://kaboomjs.com/#pos) on the bullet, using the custom value for `bulletSpeed` that we assigned to it on creation. We also check to see if the bullet has gone off the screen, and if it has, we [`destroy`](https://kaboomjs.com/#destroy) it. 
+With each frame, the action event updates the objects with the matching tag, in this case `bullet`. We call [`move`](https://kaboomjs.com/doc#pos) on the bullet, using the custom value for `bulletSpeed` that we assigned to it on creation. We also check to see if the bullet has gone off the screen, and if it has, we [`destroy`](https://kaboomjs.com/doc#destroy) it. 
 
-We also need to destroy the bullet if it hits a platform. We can do this using the Kaboom [`collides`](https://kaboomjs.com/#collides) event. Add the following code: 
+We also need to destroy the bullet if it hits a platform. We can do this using the Kaboom [`collides`](https://kaboomjs.com/doc#collides) event. Add the following code: 
 
 ```javascript
 collides("bullet","platform", (bullet, platform) =>{
@@ -343,7 +343,7 @@ We create 2 parameters for the alien's speed: a base rate and an incremental rat
 
 **Tip:** You can put these parameters and all the others we have defined at the top of the file, so that they are easy to find and adjust if you want to tweak the game parameters later. 
 
-Then we define the `spawnAlien` function. To randomly choose the side of the screen the alien will fly in from, we use the Kaboom [`choose`](https://kaboomjs.com/#choose) function, which picks an element at random from an array. From the chosen direction, we can determine the alien's starting position on the `x axis` (horizontal plane).
+Then we define the `spawnAlien` function. To randomly choose the side of the screen the alien will fly in from, we use the Kaboom [`choose`](https://kaboomjs.com/doc#choose) function, which picks an element at random from an array. From the chosen direction, we can determine the alien's starting position on the `x axis` (horizontal plane).
 
 Then we go into the calculation to figure out the speed that the alien should move at. First, we check if we need to increase the alien's speed based on the player's score. We divide the player's score by 1000 (since the aliens' speed increases with every 1000 points the player earns). We get rid of decimals by using the [`Math.floor`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/floor) function, which is built into JavaScript. The result is our `points_speed_up` value. 
 
@@ -351,13 +351,13 @@ Next we take the `ALIEN_BASE_SPEED` and add the incremental rate multiplied by o
 
 We also calculate a new rate at which aliens are spawned, making the aliens not only faster at moving, but also faster at respawning. 
 
-Now that we've calculated our basic parameters, we create a new alien using the [`add`](https://kaboomjs.com/#add) function again:
+Now that we've calculated our basic parameters, we create a new alien using the [`add`](https://kaboomjs.com/doc#add) function again:
 - `sprite('alien')` creates the alien with the image `alien`. 
 - `pos(xpos, rand(0, MAP_HEIGHT-20))` sets the starting position of the alien. We calculated the `x pos` from the randomly chosen direction. We also add a random `y` (vertical) position for the alien, between the top (position `0`) of the map, and the bottom (`MAP_HEIGHT`) of the map (screen co-ordinates start from the top left of the screen). We remove `20` pixels from the bottom bounds, to account for the ground. 
 - We add the `"alien"` tag to the object, so we can identify and call it in other parts of the code. 
 - We also add a custom object with the speed of this particular alien, broken into it's speed along the `x` and `y` axis. For the speed along the x-axis `speedX`, we add a random component so that not all aliens move at exactly the same speed. Then we multiply the speed by -1 or 1 depending on whether the alien is meant to be moving left or right across the screen. 
 
-Finally, we use Kaboom's [`wait`](https://kaboomjs.com/#wait) function to wait a short amount of time before calling `spawnAlien` again to create a new alien. We also have a call to `spawnAlien` to get it started when the game starts. 
+Finally, we use Kaboom's [`wait`](https://kaboomjs.com/doc#wait) function to wait a short amount of time before calling `spawnAlien` again to create a new alien. We also have a call to `spawnAlien` to get it started when the game starts. 
 
 
 ## Moving the Aliens
@@ -403,9 +403,9 @@ collides("alien","bullet", (alien, bullet) =>{
 
 ```
 
-This is similar to the code used before to check if a bullet has hit a platform. We [`destroy`](https://kaboomjs.com/#destroy) both the bullet and alien to remove them from the scene. Then we use the [`play`](https://kaboomjs.com/#playhttps://kaboomjs.com/#play) function to play the explosion sound effect. We set the volume so it fits in the mix, and we also put a random detune (pitch adjust) on the sound, to vary it and make it more interesting when a lot of aliens are being shot at. 
+This is similar to the code used before to check if a bullet has hit a platform. We [`destroy`](https://kaboomjs.com/doc#destroy) both the bullet and alien to remove them from the scene. Then we use the [`play`](https://kaboomjs.com/doc#playhttps://kaboomjs.com/doc#play) function to play the explosion sound effect. We set the volume so it fits in the mix, and we also put a random detune (pitch adjust) on the sound, to vary it and make it more interesting when a lot of aliens are being shot at. 
 
-We also call out to a function to create an explosion around the area where the alien bug used to be. This code is from the ["shooter" example on the Kaboom examples page](https://kaboomjs.com/examples#shooter) (which is a great game). It makes a series of bright white flashes around the explosion site, giving a cool cartoon or comic-book-like feel to the explosions. Add this code:
+We also call out to a function to create an explosion around the area where the alien bug used to be. This code is from the ["shooter" example on the Kaboom examples page](https://kaboomjs.com/demo#shooter) (which is a great game). It makes a series of bright white flashes around the explosion site, giving a cool cartoon or comic-book-like feel to the explosions. Add this code:
 
 ```javascript
 function makeExplosion(p, n, rad, size) {
@@ -455,17 +455,17 @@ The `makeExplosion` function has four _arguments_ (inputs to the function). Thes
 - `rad`, the radius or distance from `p` to make the flashes in
 - `size`, the size of each of the flashes
 
-The function creates a [`for loop`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for) to loop for `n` times (the number of main flashes we want to make). It uses the Kaboom [`wait`](https://kaboomjs.com/#wait) function to leave a little bit of time (0.1) seconds between each main flash. 
+The function creates a [`for loop`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for) to loop for `n` times (the number of main flashes we want to make). It uses the Kaboom [`wait`](https://kaboomjs.com/doc#wait) function to leave a little bit of time (0.1) seconds between each main flash. 
 
-Another `for loop` loops twice to create 2 sub flashes, using the Kaboom [`add`](https://kaboomjs.com/#add) function to add a [`rectangle`](https://kaboomjs.com/#rect) shape for each flash, and setting the color to bright white (color components in Kaboom go from 0-1). This rectangle starts out at 1 pixel in each dimension. Then the [`scale`](https://kaboomjs.com/#scale) component is added to increase the size of the flash to the `size` passed in to the function - we'll use this later when we "grow" the explosion. The [`origin`](https://kaboomjs.com/#origin) component is used to set the origin of the rectangle to it's center - this will be used when we "grow" the flash to give the impression that it is starting from a small point and exploding. We set the origin as the center so that scale is calculated from this position, giving it a more natural feel. 
+Another `for loop` loops twice to create 2 sub flashes, using the Kaboom [`add`](https://kaboomjs.com/doc#add) function to add a [`rectangle`](https://kaboomjs.com/doc#rect) shape for each flash, and setting the color to bright white (color components in Kaboom go from 0-1). This rectangle starts out at 1 pixel in each dimension. Then the [`scale`](https://kaboomjs.com/doc#scale) component is added to increase the size of the flash to the `size` passed in to the function - we'll use this later when we "grow" the explosion. The [`origin`](https://kaboomjs.com/doc#origin) component is used to set the origin of the rectangle to it's center - this will be used when we "grow" the flash to give the impression that it is starting from a small point and exploding. We set the origin as the center so that scale is calculated from this position, giving it a more natural feel. 
 
-To make the flashes appear around the position `p` that we specified, the [`pos`](https://kaboomjs.com/#pos) component is adjusted by a random amount, ranging from `-rad` to `rad`, the radius we specified (in other words, the blast area). 
+To make the flashes appear around the position `p` that we specified, the [`pos`](https://kaboomjs.com/doc#pos) component is adjusted by a random amount, ranging from `-rad` to `rad`, the radius we specified (in other words, the blast area). 
 
 Then there are references to two custom components - `lifespan` and `grow`. Kaboom allows us to define our own components to give objects any behaviour or attributes we want. All we need to do is create a function that returns an object with a method called `update`, which is then called for each frame of the object the component is added to. 
 
-Let's first look at the custom component `grow`. This is used to create the effect of the flash expanding outwards, like a firework explosion starting at a small point and getting larger until it disappears. In `grow`'s `update` function, the object is scaled up (available because we used the [`scale`](https://kaboomjs.com/#scale) component on the object) on each frame. This is calculated from the `rate` passed in - which is the size the object should grow per second, multiplied by the time difference from the last frame, using the Kaboom [`dt`](https://kaboomjs.com/#dt) function, which provides that time difference in seconds for us. The explosion flash will keep on growing in each frame, so we need a way to end the explosion before it covers the entire screen. 
+Let's first look at the custom component `grow`. This is used to create the effect of the flash expanding outwards, like a firework explosion starting at a small point and getting larger until it disappears. In `grow`'s `update` function, the object is scaled up (available because we used the [`scale`](https://kaboomjs.com/doc#scale) component on the object) on each frame. This is calculated from the `rate` passed in - which is the size the object should grow per second, multiplied by the time difference from the last frame, using the Kaboom [`dt`](https://kaboomjs.com/doc#dt) function, which provides that time difference in seconds for us. The explosion flash will keep on growing in each frame, so we need a way to end the explosion before it covers the entire screen. 
 
-This brings us to the `lifespan` component. This is implemented to automatically [`destroy`](https://kaboomjs.com/#destroy) the object after a short time, to solve the ever-growing explosion problem. It works by having a `timer` variable, which is updated each frame with the difference in time from the last frame, using the Kaboom [`dt`](https://kaboomjs.com/#dt) function again. When the `timer` count is more than the `time` parameter passed into the component, the object is automatically [`destroyed`](https://kaboomjs.com/#destroy). This creates the impression of a quick explosion blast. 
+This brings us to the `lifespan` component. This is implemented to automatically [`destroy`](https://kaboomjs.com/doc#destroy) the object after a short time, to solve the ever-growing explosion problem. It works by having a `timer` variable, which is updated each frame with the difference in time from the last frame, using the Kaboom [`dt`](https://kaboomjs.com/doc#dt) function again. When the `timer` count is more than the `time` parameter passed into the component, the object is automatically [`destroyed`](https://kaboomjs.com/doc#destroy). This creates the impression of a quick explosion blast. 
 
 ![Shooting Aliens](/images/tutorials/24-space-shooter-kaboom/shooting-aliens.gif)
 
@@ -493,7 +493,7 @@ collides("alien","ground", (alien, ground) =>{
 }); 
 ```
 
-Here we have 2 collision handlers: one for aliens hitting a platform, and one for aliens hitting the ground. They both do the same thing. First, since we have a great explosion creating function, we use it gratuitously. Then we [`destroy`](https://kaboomjs.com/#destroy) the alien object to remove it from the scene. Finally, we play an explosion sound effect at a lower volume, as this explosion is not caused by the player and doesn't directly affect them. We also add the usual random [`detune`](https://kaboomjs.com/#play) function to modify the sound each time and keep it interesting. 
+Here we have 2 collision handlers: one for aliens hitting a platform, and one for aliens hitting the ground. They both do the same thing. First, since we have a great explosion creating function, we use it gratuitously. Then we [`destroy`](https://kaboomjs.com/doc#destroy) the alien object to remove it from the scene. Finally, we play an explosion sound effect at a lower volume, as this explosion is not caused by the player and doesn't directly affect them. We also add the usual random [`detune`](https://kaboomjs.com/doc#play) function to modify the sound each time and keep it interesting. 
 
 
 ## Adding Score and Shield UI
@@ -518,7 +518,7 @@ const scoreText = add ([
 ]);
 ```
 
-Here we add two new objects, rendered with the [`text`](https://kaboomjs.com/#text) component. The first is just the static label for the score. The second is the text placeholder for the actual score. Note that the [`layer`](https://kaboomjs.com/#layer) component is used in both cases to place the text on the UI layer we created at the start of the tutorial. We haven't had to specify the layer for all our other game objects, because we set the `obj` layer as the default to use when we defined the layers. 
+Here we add two new objects, rendered with the [`text`](https://kaboomjs.com/doc#text) component. The first is just the static label for the score. The second is the text placeholder for the actual score. Note that the [`layer`](https://kaboomjs.com/doc#layer) component is used in both cases to place the text on the UI layer we created at the start of the tutorial. We haven't had to specify the layer for all our other game objects, because we set the `obj` layer as the default to use when we defined the layers. 
 
 Now that we have the UI components for showing the score, we need a function to update the score when it changes, and reflect it on the UI. 
 
@@ -534,7 +534,7 @@ function updateScore(points){
 ```
 This `updateScore` function takes as its argument the number of points to add to the score and adds them to the player's current score - remember we added `score` as a custom property when we created the player (spaceship) object. 
 
-Next we update the `scoreText` UI element we created previously. The player's score is converted to a string using JavaScript's [`toString`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/toString) method, which is part of every object in JavaScript. It is also modified with [`padStart`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/padStart), which makes sure the resulting score string is exactly `6` digits long, using 0s to put in front of the string (`start`) if the number is smaller than 6 digits long. This makes nice placeholders for the score, and gives a cue to the users as to the maximum score they could reach. Finally, we play a little sound to indicate that points have been earned. As before, we vary the pitch each time using [`detune`](https://kaboomjs.com/#play) to keep the sound fresh.
+Next we update the `scoreText` UI element we created previously. The player's score is converted to a string using JavaScript's [`toString`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/toString) method, which is part of every object in JavaScript. It is also modified with [`padStart`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/padStart), which makes sure the resulting score string is exactly `6` digits long, using 0s to put in front of the string (`start`) if the number is smaller than 6 digits long. This makes nice placeholders for the score, and gives a cue to the users as to the maximum score they could reach. Finally, we play a little sound to indicate that points have been earned. As before, we vary the pitch each time using [`detune`](https://kaboomjs.com/doc#play) to keep the sound fresh.
 
 The next UI element to add is the ship's shield health. This would be great as a kind of health-bar-style display, that starts out green and turns red when the shield is low. The game should end when the shield is fully depleted, as the spaceship is then totally destroyed. 
 
@@ -618,9 +618,9 @@ Then the function updates the color of the bar depending on the health of the sh
 
 The final step in the shield health function is to check if the shield health is depleted, and end the game if it is.
 
-When the game ends, we destroy the spaceship to remove it from the scene. Now we have another opportunity to create some more explosions using the `makeExplosion` function we added earlier. This time we can go really big! To make a big impact, we create a `for` loop to set off 500 explosions all over the screen for seriously dramatic effect. We use the Kaboom [`wait`](https://kaboomjs.com/#wait) function to have a small delay between each explosion so that they don't all go off at once. Then we make each explosion happen at random positions on the map, passing in other parameters to the `makeExplosion` function to set the blast radius, number of sub-explosions and general size. We also play the `explosion` sound effect using Kaboom's [`play`](https://kaboomjs.com/#play) function. This time we don't adjust the volume down, as we want the sound to be as dramatic as possible. We detune it randomly again to create a true cacophony and sense of mayhem. 
+When the game ends, we destroy the spaceship to remove it from the scene. Now we have another opportunity to create some more explosions using the `makeExplosion` function we added earlier. This time we can go really big! To make a big impact, we create a `for` loop to set off 500 explosions all over the screen for seriously dramatic effect. We use the Kaboom [`wait`](https://kaboomjs.com/doc#wait) function to have a small delay between each explosion so that they don't all go off at once. Then we make each explosion happen at random positions on the map, passing in other parameters to the `makeExplosion` function to set the blast radius, number of sub-explosions and general size. We also play the `explosion` sound effect using Kaboom's [`play`](https://kaboomjs.com/doc#play) function. This time we don't adjust the volume down, as we want the sound to be as dramatic as possible. We detune it randomly again to create a true cacophony and sense of mayhem. 
 
-After setting off all those sound effects and visual fireworks, we [`wait`](https://kaboomjs.com/#wait) for 2 seconds for everything to settle down, and then use the Kaboom function [`go`](https://kaboomjs.com/#go) to switch to a new scene, `endGame`, and wait for the player to play again. To add this new scene, click the "+" button next to the "Scenes" collection in the left menu, and type in `endGame`. Then add this code to the new scene: 
+After setting off all those sound effects and visual fireworks, we [`wait`](https://kaboomjs.com/doc#wait) for 2 seconds for everything to settle down, and then use the Kaboom function [`go`](https://kaboomjs.com/doc#go) to switch to a new scene, `endGame`, and wait for the player to play again. To add this new scene, click the "+" button next to the "Scenes" collection in the left menu, and type in `endGame`. Then add this code to the new scene: 
 
 ```javascript
 const MAP_WIDTH = 440; 
@@ -639,7 +639,7 @@ keyRelease("enter", ()=>{
 });
 ```
 
-This scene [`adds`](https://kaboomjs.com/#add) a large "GAME OVER" text over the screen until the player presses and releases the `enter` key.  Then the [`keyRelease`](https://kaboomjs.com/#keyRelease) event returns the player to the main scene, and uses [`go`](https://kaboomjs.com/#go) to switch scenes and restart the game. Because this is a new scene, in a new scope, we need to add the `MAP_WIDTH` and `MAP_HEIGHT` constants again. 
+This scene [`adds`](https://kaboomjs.com/doc#add) a large "GAME OVER" text over the screen until the player presses and releases the `enter` key.  Then the [`keyRelease`](https://kaboomjs.com/doc#keyRelease) event returns the player to the main scene, and uses [`go`](https://kaboomjs.com/doc#go) to switch scenes and restart the game. Because this is a new scene, in a new scope, we need to add the `MAP_WIDTH` and `MAP_HEIGHT` constants again. 
 
 ## Allowing the Alien Bugs to Attack
 
@@ -662,9 +662,9 @@ overlaps("alien", "player", (alien, player) =>{
 }); 
 ```
 
-This time, instead of the [`collides`](https://kaboomjs.com/#collides) collision detector, we use [`overlaps`](https://kaboomjs.com/#overlaps). This allows for near misses and makes for better visual effects when an alien bug crashes into the space ship. The difference between `collides` and `overlaps` is that the collision detector will call our given function even if just the edges of the game objects touch, whereas `overlaps` requires the game objects to be more than just touching, i.e. there must be at least 1 pixel overlap, before firing the callback function.
+This time, instead of the [`collides`](https://kaboomjs.com/doc#collides) collision detector, we use [`overlaps`](https://kaboomjs.com/doc#overlaps). This allows for near misses and makes for better visual effects when an alien bug crashes into the space ship. The difference between `collides` and `overlaps` is that the collision detector will call our given function even if just the edges of the game objects touch, whereas `overlaps` requires the game objects to be more than just touching, i.e. there must be at least 1 pixel overlap, before firing the callback function.
 
-This is a big event - it's the way the ship shield gets damaged and it can be fatal - so we want to add a bit more dramatic effect. Kaboom can create a cool screen-shaking effect, as if the player has been hit, which we can invoke by calling [`camShake`](https://kaboomjs.com/#camShake) with a number representing how dramatic the shake should be. Then we add some visual effect with the `makeExplosion` function. We also destroy the alien and [`play`](https://kaboomjs.com/#play) the `explosion` effect again, this time a bit louder as the alien exploding has directly affected the player. We also detune the effect to the lowest pitch we can, to make it "feel" more direct, particularly if the player has a sub-woofer. 
+This is a big event - it's the way the ship shield gets damaged and it can be fatal - so we want to add a bit more dramatic effect. Kaboom can create a cool screen-shaking effect, as if the player has been hit, which we can invoke by calling [`camShake`](https://kaboomjs.com/doc#camShake) with a number representing how dramatic the shake should be. Then we add some visual effect with the `makeExplosion` function. We also destroy the alien and [`play`](https://kaboomjs.com/doc#play) the `explosion` effect again, this time a bit louder as the alien exploding has directly affected the player. We also detune the effect to the lowest pitch we can, to make it "feel" more direct, particularly if the player has a sub-woofer. 
 
 Then we call the `updatePlayerShield` function we defined previously, with a constant that defines by how much a shield is damaged per hit. You can move the constant to the top of the main scene file to keep it neat if you want. 
 
@@ -697,17 +697,17 @@ action("gem", (gem)=>{
 spawnGem(); 
 ```
 
-On this weird planet in outer space, the gems rain from the sky, which is the top of the map for our purposes. We calculate a random position, `xpos`, along the `x` axis for the gem to appear on by calling the Kaboom [`rand`](https://kaboomjs.com/#rand) function. We don't want the gems to fall right at the edge of the screen, as they will be cut off and the spaceship won't be able to get to them because of the `boundary` elements we added all around the screen. So we limit the random `xpos` to one `BLOCK_SIZE` from each edge. 
+On this weird planet in outer space, the gems rain from the sky, which is the top of the map for our purposes. We calculate a random position, `xpos`, along the `x` axis for the gem to appear on by calling the Kaboom [`rand`](https://kaboomjs.com/doc#rand) function. We don't want the gems to fall right at the edge of the screen, as they will be cut off and the spaceship won't be able to get to them because of the `boundary` elements we added all around the screen. So we limit the random `xpos` to one `BLOCK_SIZE` from each edge. 
 
-Now we [`add`](https://kaboomjs.com/#add) the gem sprite to the scene. The `pos` component is set to the `xpos` we calculated, with the `y` component set to one `BLOCK_SIZE` from the top of the screen. This is to avoid the gem getting stuck on our upper `boundary`. We also give the gem the [`body`](https://kaboomjs.com/#body) component, which makes it subject to Kaboom gravity so that it falls down towards the ground. We give it the label `gem` so that we can refer to it later. 
+Now we [`add`](https://kaboomjs.com/doc#add) the gem sprite to the scene. The `pos` component is set to the `xpos` we calculated, with the `y` component set to one `BLOCK_SIZE` from the top of the screen. This is to avoid the gem getting stuck on our upper `boundary`. We also give the gem the [`body`](https://kaboomjs.com/doc#body) component, which makes it subject to Kaboom gravity so that it falls down towards the ground. We give it the label `gem` so that we can refer to it later. 
 
-Then we add the [`action`](https://kaboomjs.com/#action) event handler for the gem - we need to do this for all objects with a `body` component so that interactions with [`solid`](https://kaboomjs.com/#solid) objects are taken care of. We do this by calling the `resolve` method on the gem. Sometimes, if the frame rate gets too low (if there's a lot of action, or the computer's slow), the `resolve` function may miss a `body` and `solid` interaction, and the [`object falls through the solid`](https://github.com/replit/kaboom/issues/86). This could cause gems to fall through the ground, out of reach of the player's spaceship. To account for this possibility, we check if the gem's `y` position is beyond the bounds of the map, and destroy it and spawn a new gem if it is. 
+Then we add the [`action`](https://kaboomjs.com/doc#action) event handler for the gem - we need to do this for all objects with a `body` component so that interactions with [`solid`](https://kaboomjs.com/doc#solid) objects are taken care of. We do this by calling the `resolve` method on the gem. Sometimes, if the frame rate gets too low (if there's a lot of action, or the computer's slow), the `resolve` function may miss a `body` and `solid` interaction, and the [`object falls through the solid`](https://github.com/replit/kaboom/issues/86). This could cause gems to fall through the ground, out of reach of the player's spaceship. To account for this possibility, we check if the gem's `y` position is beyond the bounds of the map, and destroy it and spawn a new gem if it is. 
 
 Finally, we call `spawnGem()` to start the gem raining process. 
 
 ## Collecting Gems
 
-Now that gems are raining down, we can add a handler to pick up when the player's spaceship moves over a gem. This is how the spaceship "collects" gems, and will earn the player points. Add the following [`overlaps`](https://kaboomjs.com/#overlaps) event handler:
+Now that gems are raining down, we can add a handler to pick up when the player's spaceship moves over a gem. This is how the spaceship "collects" gems, and will earn the player points. Add the following [`overlaps`](https://kaboomjs.com/doc#overlaps) event handler:
 
 ```javascript
 const POINTS_PER_GEM = 100; 
@@ -718,7 +718,7 @@ overlaps("player","gem", (player, gem) =>{
     wait(1, spawnGem); 
 });
 ```
-This fires whenever the spaceship and a gem overlap. We [`destroy`](https://kaboomjs.com/#destroy) the gem to remove it from the scene, and call the `updateScore` function we added earlier to update the player's points by the amount declared in the `POINTS_PER_GEM` constant. Then we [`wait`](https://kaboomjs.com/#wait) one second before another gem is spawned for the player to collect.
+This fires whenever the spaceship and a gem overlap. We [`destroy`](https://kaboomjs.com/doc#destroy) the gem to remove it from the scene, and call the `updateScore` function we added earlier to update the player's points by the amount declared in the `POINTS_PER_GEM` constant. Then we [`wait`](https://kaboomjs.com/doc#wait) one second before another gem is spawned for the player to collect.
 
 Run the code now and start collecting gems.
 

--- a/tutorials/25-build-3d-game-with-kaboom.md
+++ b/tutorials/25-build-3d-game-with-kaboom.md
@@ -15,7 +15,7 @@ Here's what we want from this game:
 - A sense of depth to give the illusion of 3D
 - The feeling of freedom of movement throughout space
 
-We'll make use of Kaboom's [scale component](https://kaboomjs.com/#scale) to achieve the sense of depth, representing our sprites as smaller if they are meant to be further away, and larger when they are closer. We'll  create a feeling of moving through space using an algorithm to generate a star field, like the early Windows screensavers. 
+We'll make use of Kaboom's [scale component](https://kaboomjs.com/doc#scale) to achieve the sense of depth, representing our sprites as smaller if they are meant to be further away, and larger when they are closer. We'll  create a feeling of moving through space using an algorithm to generate a star field, like the early Windows screensavers. 
 
 ## Creating a new project
 
@@ -99,12 +99,12 @@ loop(0.8, spawnAlien);
 
 First, we define some general constants for the size of the screen and the speed at which aliens will move. This way, we don't have to keep remembering and typing numbers, and it's easier to change these aspects later if we need to. We also create an array to hold each alien object we create so that we can keep track of all of them. This will be especially important when we add movement to the aliens. 
 
-The function `spawnAlien` creates a new alien at a random location on the screen. The first lines calculate a random x and y position to place the alien on the screen initially. This isn't logically needed, as we'll calculate the alien's actual position later from our 3D coordinate system and calculate the projected screen position on each frame. But we need to pass a position [`pos`](https://kaboomjs.com/#pos) component to the [`add`](https://kaboomjs.com/#add) method when we create a new object, so any random position will do. 
+The function `spawnAlien` creates a new alien at a random location on the screen. The first lines calculate a random x and y position to place the alien on the screen initially. This isn't logically needed, as we'll calculate the alien's actual position later from our 3D coordinate system and calculate the projected screen position on each frame. But we need to pass a position [`pos`](https://kaboomjs.com/doc#pos) component to the [`add`](https://kaboomjs.com/doc#add) method when we create a new object, so any random position will do. 
 
 There are two more components we include when constructing the alien object:
 
-- [`scale`](https://kaboomjs.com/#scale), allowing us to adjust the size of the alien over time as if it's getting closer, and
-- [`rotate`](https://kaboomjs.com/#rotate), allowing us to rotate the aliens so we can simulate 'rolling' when changing the spaceship's direction.
+- [`scale`](https://kaboomjs.com/doc#scale), allowing us to adjust the size of the alien over time as if it's getting closer, and
+- [`rotate`](https://kaboomjs.com/doc#rotate), allowing us to rotate the aliens so we can simulate 'rolling' when changing the spaceship's direction.
 
 We also add the coordinates of the alien's position in the 3D system to the alien object as custom properties. We start with a fixed `zpos`, or position on the Z axis, far from the screen.
 
@@ -112,7 +112,7 @@ Then we set the alien's speed, varied by a random amount of up to half the base 
 
 Finally, we add the new alien to the `aliens` array we created earlier to keep track of it. 
 
-Outside the function, we make use of the Kaboom [`loop`](https://kaboomjs.com/#loop) functionality to call the `spawnAlien` function to create new aliens at regular intervals. 
+Outside the function, we make use of the Kaboom [`loop`](https://kaboomjs.com/doc#loop) functionality to call the `spawnAlien` function to create new aliens at regular intervals. 
 
 ## Moving the alien bugs
 
@@ -141,7 +141,7 @@ Now we need to have the aliens we've generated move with each frame. Here's the 
     }
 ```
 
-First we add a new event handler onto the [`action`](https://kaboomjs.com/#action) event, and filter for any objects tagged `alien`. The `action` event handler is fired for each frame. In this event handler function, we adjust the `zpos` of the alien to make it 'move' a little closer to the screen. We use the [`dt()`](https://kaboomjs.com/#dt) function to get the time from the last frame, together with the speed per second we assigned to the alien when we constructed it, to calculate the alien's new `zpos` in our 3D coordinate system. We then translate that value to screen coordinates, and mimic the z-axis position by adjusting the size, or `scale`, of the alien sprite. 
+First we add a new event handler onto the [`action`](https://kaboomjs.com/doc#action) event, and filter for any objects tagged `alien`. The `action` event handler is fired for each frame. In this event handler function, we adjust the `zpos` of the alien to make it 'move' a little closer to the screen. We use the [`dt()`](https://kaboomjs.com/doc#dt) function to get the time from the last frame, together with the speed per second we assigned to the alien when we constructed it, to calculate the alien's new `zpos` in our 3D coordinate system. We then translate that value to screen coordinates, and mimic the z-axis position by adjusting the size, or `scale`, of the alien sprite. 
 
 Remember that screen coordinates start with (0,0) in the top left corner of the screen, and our 3D coordinate system starts with (0,0,0) in the 'center' of the system. To translate between the 2 systems, we need to find the center of the screen so that we can center the 3D system over it. We do this by by halving the screen `WIDTH` and `HEIGHT` by 2. The screen is the red rectangle in the image below, showing how the 3D system will be centered on it. 
 
@@ -208,15 +208,15 @@ While this is very similar to the code we added above for the alien bugs, you'll
 
 - We create all the stars at once. This is because we need a significant star field to start with, not just a few stars every second. 
 - We don't create a Kaboom object for each star. This is because we don't need the collision handling and other overhead that comes with a Kaboom object, especially since we are generating a lot of stars (`const STAR_COUNT = 1000; `). Instead, we store the stars' info in custom [object literals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Grammar_and_types#object_literals), and add each of these to the `stars` array.  
-- We set the initial `z-pos` of the stars to a random value from 0 to 1000, using the Kaboom [`rand`](https://kaboomjs.com/#rand) function. We do this because we create all the stars at once, so we seed the stars at random positions on the z-axis to give the feeling of depth to the star field. If the stars were all initialised to the same `z-pos`, they would move in unison, and it would look like a mass of pixels were coming at us - a bit weird!
+- We set the initial `z-pos` of the stars to a random value from 0 to 1000, using the Kaboom [`rand`](https://kaboomjs.com/doc#rand) function. We do this because we create all the stars at once, so we seed the stars at random positions on the z-axis to give the feeling of depth to the star field. If the stars were all initialised to the same `z-pos`, they would move in unison, and it would look like a mass of pixels were coming at us - a bit weird!
 
-Now take a look at the [`action`](https://kaboomjs.com/#action) event handler for our stars. It differs from the event handler for our alien bugs in a few ways:
+Now take a look at the [`action`](https://kaboomjs.com/doc#action) event handler for our stars. It differs from the event handler for our alien bugs in a few ways:
 
 - We don't use an object filter to look for the stars, as we didn't create them as Kaboom objects. Instead, we just cycle through each star in the `stars` array. 
 - Instead of destroying the star and removing it from the array when it reaches the 'front' of the screen, we recycle it by resetting its `z-pos` back to 1000. 
 - We also check if the star is out of the screen view. If it is, we don't draw it, to save a bit of overhead. 
 - Instead of using the `z-pos` to calculate a value by which to scale the star, we use it to calculate the star's intensity, or brightness. Kaboom uses color values in the range 0-1. So we first scale the `z-pos` down to below 1. Then we subtract it from 1 (the maximum color value, i.e. brightest value) to create an inverse relationship between `z-pos` and intensity. In other words, stars further away from us have higher `zpos` values, giving us lower color intensity. This makes stars far away glow dimly, while those closer to our view look brighter. 
-- Finally, we use the Kaboom's [drawRect](https://kaboomjs.com/#drawRect) method to directly draw the star to the screen. As there is no pixel level drawing function in Kaboom, we create a rectangle of size 1 to draw just one pixel. 
+- Finally, we use the Kaboom's [drawRect](https://kaboomjs.com/doc#drawRect) method to directly draw the star to the screen. As there is no pixel level drawing function in Kaboom, we create a rectangle of size 1 to draw just one pixel. 
 
 ## Adding the spaceship cockpit
 
@@ -233,7 +233,7 @@ Now that we have a star field to fly through, let's add the player's spaceship. 
     ]);
 ```
 
-This adds the `cockpit` sprite (image) to the `ui` layer. We also add the [`rotate`](https://kaboomjs.com/#rotate) component to it, so that we can add some rotation effects when the spaceship is flying. We use the [`origin`](https://kaboomjs.com/#origin) component to center the image in the middle of the screen, which also provides the axis to rotate the sprite around when banking (turning) the spaceship. Then we use a scaling factor to [`scale`](https://kaboomjs.com/#scale) the image down to the size of the screen. We scale the image as it's much larger (1334×834) than the size of the game screen (320x200). We could resize the image in an image editing programme, but we would lose some detail and sharpness. Note that the factor of the scale means that the image is still a little larger than the screen size. This gives us a bit of overlap available for when we rotate the image when banking the spaceship. 
+This adds the `cockpit` sprite (image) to the `ui` layer. We also add the [`rotate`](https://kaboomjs.com/doc#rotate) component to it, so that we can add some rotation effects when the spaceship is flying. We use the [`origin`](https://kaboomjs.com/doc#origin) component to center the image in the middle of the screen, which also provides the axis to rotate the sprite around when banking (turning) the spaceship. Then we use a scaling factor to [`scale`](https://kaboomjs.com/doc#scale) the image down to the size of the screen. We scale the image as it's much larger (1334×834) than the size of the game screen (320x200). We could resize the image in an image editing programme, but we would lose some detail and sharpness. Note that the factor of the scale means that the image is still a little larger than the screen size. This gives us a bit of overlap available for when we rotate the image when banking the spaceship. 
 
 Run the game now and you should see the view from inside the spaceship. 
 
@@ -306,9 +306,9 @@ Now we can add some event handlers for keyboard input:
     }); 
 ```
 
-Because we're moving the aliens and stars to make it appear as if the spaceship is moving, these elements must move in the opposite direction to that of the arrow key being used. When we use the left key to move the spaceship, our scene moves to the right. We use the Kaboom events [`keyDown`](https://kaboomjs.com/#keyDown) and [`keyRelease`](https://kaboomjs.com/#keyRelease) to attach event handlers for direction controls to the arrow keys on the keyboard. In each of the `keyDown` event handlers, we get the time elapsed from the last frame by calling the [`dt()`](https://kaboomjs.com/#dt) function, and multiply it by a constant `MOVE_DELTA`, representing the amount to move by each second. For the `right` and `up` keys, our elements move left and down respectively, so we make the amount to move negative - recall that we are moving the objects in our 3D coordinate system. Then we call the 2 helper functions we defined above with the amount to move the objects in the `x` and `y` dimensions. 
+Because we're moving the aliens and stars to make it appear as if the spaceship is moving, these elements must move in the opposite direction to that of the arrow key being used. When we use the left key to move the spaceship, our scene moves to the right. We use the Kaboom events [`keyDown`](https://kaboomjs.com/doc#keyDown) and [`keyRelease`](https://kaboomjs.com/doc#keyRelease) to attach event handlers for direction controls to the arrow keys on the keyboard. In each of the `keyDown` event handlers, we get the time elapsed from the last frame by calling the [`dt()`](https://kaboomjs.com/doc#dt) function, and multiply it by a constant `MOVE_DELTA`, representing the amount to move by each second. For the `right` and `up` keys, our elements move left and down respectively, so we make the amount to move negative - recall that we are moving the objects in our 3D coordinate system. Then we call the 2 helper functions we defined above with the amount to move the objects in the `x` and `y` dimensions. 
 
-In the event handlers for `left` and `right` keys, we also make use of the Kaboom [`camRot`](https://kaboomjs.com/#camRot) effect. This effect rotates all objects by the amount we specify, giving the perception of the spaceship banking hard while turning. We add in two additional event handlers on [`keyRelease`](https://kaboomjs.com/#keyRelease) for the `left` and `right` keys to reset the rotation when the player stops turning. 
+In the event handlers for `left` and `right` keys, we also make use of the Kaboom [`camRot`](https://kaboomjs.com/doc#camRot) effect. This effect rotates all objects by the amount we specify, giving the perception of the spaceship banking hard while turning. We add in two additional event handlers on [`keyRelease`](https://kaboomjs.com/doc#keyRelease) for the `left` and `right` keys to reset the rotation when the player stops turning. 
 
 Give the game a run, and you should be able to control the spaceship. 
 
@@ -337,7 +337,7 @@ const horizontal_crosshair = add([
 ]);
 
 ```
-This adds 2 lines at a point halfway across the screen, and about 1/3 down the screen, which is roughly the center of the view out of the spaceship window. Since Kaboom doesn't have a line component, we use [`rect`](https://kaboomjs.com/#rect) to draw rectangles with a width of 1 pixel, effectively a line. We add the cross hairs to the UI layer, so they are always on top of the aliens and stars. 
+This adds 2 lines at a point halfway across the screen, and about 1/3 down the screen, which is roughly the center of the view out of the spaceship window. Since Kaboom doesn't have a line component, we use [`rect`](https://kaboomjs.com/doc#rect) to draw rectangles with a width of 1 pixel, effectively a line. We add the cross hairs to the UI layer, so they are always on top of the aliens and stars. 
 
 Now we have a point to aim at, let's add the lasers. Our player will shoot using the spacebar, and we want a classic laser effect: 2 lasers, one shooting from each side of the ship towards the same point to give the effect of shooting into the distance, towards a vanishing point. 
 
@@ -412,7 +412,7 @@ keyDown("space", () => {
 });
 
 ```
-Here we use the [`action`](https://kaboomjs.com/#action) event handler, filtered to `bullet` objects.
+Here we use the [`action`](https://kaboomjs.com/doc#action) event handler, filtered to `bullet` objects.
 
 To calculate the bullet's next position on its trajectory for each frame, we need to find the values for the slope (`m`) and y-intercept (in this case, `c`) of the straight line between the bullet's current position and its end position. Our first 2 lines of the function express those variable parameters as formulas. Let's take a moment to see how we came to those formulas.
 
@@ -445,7 +445,7 @@ Now that we can express `m` and `c` as formulas, we use them in our code to calc
 
 Our code goes on to advance the bullet's current `x` position by the bullet speed amount, and we can figure out the corresponding new `y` position using the `m` and `c` values calculated above with our new `x` position. We then update the bullet's new position (`pos`) with these new values.
 
-We want the bullets to disappear once they hit the target at the vanishing point, so we go on to check if the bullet has crossed the horizontal cross hairs. If it has, we remove the bullet from the scene using the [`destroy`](https://kaboomjs.com/#destroy) function. 
+We want the bullets to disappear once they hit the target at the vanishing point, so we go on to check if the bullet has crossed the horizontal cross hairs. If it has, we remove the bullet from the scene using the [`destroy`](https://kaboomjs.com/doc#destroy) function. 
 
 Finally, we have an event handler for the `space` key, which calls the `spawnBullet` function whenever it is pressed. 
 
@@ -469,7 +469,7 @@ collides("alien","bullet", (alien, bullet) =>{
 
 ```
 
-We make use of the Kaboom event [`collides`](https://kaboomjs.com/#collides) which is fired when 2 game objects are overlapping or touching each other. We pass in the tags for the aliens and bullets, so we know when they collide.
+We make use of the Kaboom event [`collides`](https://kaboomjs.com/doc#collides) which is fired when 2 game objects are overlapping or touching each other. We pass in the tags for the aliens and bullets, so we know when they collide.
 
 We want to limit bullet hits to only be around the target area, so that the 3D perspective is kept. But because they could collide at any point along the path the bullet takes, we check if the collision has taken place at around the cross hairs area. Then, if is in the target zone, we remove both the bullet and the alien from the scene, and call a function to create an explosion effect. This is the same code used in the [2D Space Shooter tutorial](https://docs.replit.com/tutorials/24-build-space-shooter-with-kaboom). 
 
@@ -523,7 +523,7 @@ Run this now, and you should be able to shoot the alien bugs down.
 
 ## Checking if alien bugs hit the spaceship
 
-Now we can add functionality to check if an alien bug makes it past our laser and explodes into the spaceship. Since the cockpit covers the entire screen, we can't make use of the [`collides`](https://kaboomjs.com/#collides) function to check if an alien has hit the cockpit, as it would always be colliding. Instead, we can check the `z` value of the alien, plus if it is within an area of the spacecraft that would cause damage. We'll use a "strike zone" in the center of the cockpit view as the area that aliens can do damage to the craft. Outside that area, we'll assume that the aliens go around or up and over the spacecraft. 
+Now we can add functionality to check if an alien bug makes it past our laser and explodes into the spaceship. Since the cockpit covers the entire screen, we can't make use of the [`collides`](https://kaboomjs.com/doc#collides) function to check if an alien has hit the cockpit, as it would always be colliding. Instead, we can check the `z` value of the alien, plus if it is within an area of the spacecraft that would cause damage. We'll use a "strike zone" in the center of the cockpit view as the area that aliens can do damage to the craft. Outside that area, we'll assume that the aliens go around or up and over the spacecraft. 
 
 To implement this scheme, add a definition for the strike zone: 
 
@@ -550,7 +550,7 @@ Then we can modify the `action("alien",....)` event handler that we added earlie
 
 We've modified the code to check if the alien is really close to us (`alien.zpos < 1 `), and if it is, we check if it is within the bounds of the `STRIKE_ZONE` area. The strike zone is a rectangle - you could implement more complex shapes if you wanted to be more accurate about where the alien can hit. However, a rectangle approximation is OK for this game. 
 
-If the alien is close enough, and within our strike zone, we use the [`camShake`](https://kaboomjs.com/#camShake) effect to make it "feel" like we've been hit. Then we create an explosion at the point of impact for some visual effects. 
+If the alien is close enough, and within our strike zone, we use the [`camShake`](https://kaboomjs.com/doc#camShake) effect to make it "feel" like we've been hit. Then we create an explosion at the point of impact for some visual effects. 
 
 ![Colliding](/images/tutorials/25-3d-game-kaboom/colliding.gif)
 

--- a/tutorials/27-build-tictactoe-with-websockets-kaboom.md
+++ b/tutorials/27-build-tictactoe-with-websockets-kaboom.md
@@ -419,13 +419,13 @@ keyRelease("enter", ()=>{
 
 To keep the calculations for the UI layout simpler, we'll use a fixed size for the screen. That's where the 2 constants for the screen width and height come in. 
 
-We use the Kaboom [`add`](https://kaboomjs.com/#add) function to display the prompt "What's your name?" on the screen, using the  [`text`](https://kaboomjs.com/#text) component. We choose a position halfway across the screen, `SCREEN_WIDTH / 2`, and about a third of the way down the screen, `SCREEN_HEIGHT / 3`. We add the [`origin`](https://kaboomjs.com/#origin) component, set to `center`, to indicate that the positions we set must be in the center of the text field. 
+We use the Kaboom [`add`](https://kaboomjs.com/doc#add) function to display the prompt "What's your name?" on the screen, using the  [`text`](https://kaboomjs.com/doc#text) component. We choose a position halfway across the screen, `SCREEN_WIDTH / 2`, and about a third of the way down the screen, `SCREEN_HEIGHT / 3`. We add the [`origin`](https://kaboomjs.com/doc#origin) component, set to `center`, to indicate that the positions we set must be in the center of the text field. 
 
 Then we add another object with an empty `""` text component. This will display the characters the player types in. We position it exactly halfway down and across the screen. We also hold a reference to the object in the constant `nameField`.
 
-To get the user's keyboard input, we use the Kaboom function [`charInput`](https://kaboomjs.com/#charInput). This function calls an event handler each time a key on the keyboard is pressed. We take that character and append it to the text in the `nameField` object. Now, when a player presses a key to enter their name, it will show up on the screen. 
+To get the user's keyboard input, we use the Kaboom function [`charInput`](https://kaboomjs.com/doc#charInput). This function calls an event handler each time a key on the keyboard is pressed. We take that character and append it to the text in the `nameField` object. Now, when a player presses a key to enter their name, it will show up on the screen. 
 
-Finally, we use the Kaboom function [`keyRelease`](https://kaboomjs.com/#keyRelease) to listen for when the player pushes the `enter` key. We'll take that as meaning they have finished entering their name and want to start the game. In the handler, we use the Kaboom [`go`](https://kaboomjs.com/#go) function to redirect to the main scene of the game. 
+Finally, we use the Kaboom function [`keyRelease`](https://kaboomjs.com/doc#keyRelease) to listen for when the player pushes the `enter` key. We'll take that as meaning they have finished entering their name and want to start the game. In the handler, we use the Kaboom [`go`](https://kaboomjs.com/doc#go) function to redirect to the main scene of the game. 
 
 ## Setting Kaboom parameters
 
@@ -501,7 +501,7 @@ function createTextBoxesForGrid(){
 
 createTextBoxesForGrid();     
 ```
-This function uses the array [`forEach`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach) method to loop through each "square" definition in the `boardSquares` array. We then find the center `x` and `y` of the square, and [`add`](https://kaboomjs.com/#add) a new text object to the screen, and also add it to the square definition on the field `textBox` so we can access it later to update it. We use the `origin` component to ensure the text is centered in the square. 
+This function uses the array [`forEach`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach) method to loop through each "square" definition in the `boardSquares` array. We then find the center `x` and `y` of the square, and [`add`](https://kaboomjs.com/doc#add) a new text object to the screen, and also add it to the square definition on the field `textBox` so we can access it later to update it. We use the `origin` component to ensure the text is centered in the square. 
 
 Finally, we call the function to create the text boxes. 
 
@@ -527,7 +527,7 @@ const statusLabel = add([
   color(0,1,0)
 ]); 
 ```
-Here we add 3 objects with [`text`](https://kaboomjs.com/#text) components. The first 2 are placeholders for the player names and symbols. The third one is for the game status. They are positioned to the right of the screen, and contain empty text to start. We'll change the contents as we receive new game states from the server. The last object has a `color` component to set the color of the text to green. This is to make the status message stand out from the rest of the text.  
+Here we add 3 objects with [`text`](https://kaboomjs.com/doc#text) components. The first 2 are placeholders for the player names and symbols. The third one is for the game status. They are positioned to the right of the screen, and contain empty text to start. We'll change the contents as we receive new game states from the server. The last object has a `color` component to set the color of the text to green. This is to make the status message stand out from the rest of the text.  
 
 
 ## Connecting to the server
@@ -629,7 +629,7 @@ You can connect to your game in another browser tab, and enter another name. The
 
 ## Handling player moves
 
-We want a player to be able to click on a block to place their move. Kaboom has a function [`mouseRelease`](https://kaboomjs.com/#mouseRelease) that we can use to handle mouse click events. All we need then is the position the mouse cursor is at, and we can map that to one of the board positions using our `boardSquares` array to do the lookup. We'll use the Kaboom function [`mousePos`](https://kaboomjs.com/#mousePos) to get the coordinates of the mouse: 
+We want a player to be able to click on a block to place their move. Kaboom has a function [`mouseRelease`](https://kaboomjs.com/doc#mouseRelease) that we can use to handle mouse click events. All we need then is the position the mouse cursor is at, and we can map that to one of the board positions using our `boardSquares` array to do the lookup. We'll use the Kaboom function [`mousePos`](https://kaboomjs.com/doc#mousePos) to get the coordinates of the mouse: 
 
 ```js
 mouseRelease(() => {
@@ -651,7 +651,7 @@ mouseRelease(() => {
 ```
 If we find a 'hit' on one of the board squares, we emit our `action` event. We pass the index of the square that was clicked on as the payload data. The server listens for this event, and runs the logic we added for the `action` event on the server side. If the action changes the game state, the server will send back the new game state, and the UI elements update. 
 
-The only other input we need to implement is to check if the player wants a rematch. To do that, we'll assign the `r` key as the rematch command. We can use the Kaboom function [`charInput`](https://kaboomjs.com/#charInput) to listen for key press events. We'll check if the key is `r`, or `R`, then emit the `rematch` event. We don't have any data to pass with that, so we'll just pass `null`. 
+The only other input we need to implement is to check if the player wants a rematch. To do that, we'll assign the `r` key as the rematch command. We can use the Kaboom function [`charInput`](https://kaboomjs.com/doc#charInput) to listen for key press events. We'll check if the key is `r`, or `R`, then emit the `rematch` event. We don't have any data to pass with that, so we'll just pass `null`. 
 
 ```js
 charInput((ch) => {


### PR DESCRIPTION
-  fixed the links to kaboom doc sections in the kaboom tutorials which were broken after the recent update to the documentation site
- marked example links as code so that they won't get flagged as broken links