### PR TITLE
Update kaboom tutorials to suggested API style

### DIFF
--- a/tutorials/21-build-snake-with-kaboom.md
+++ b/tutorials/21-build-snake-with-kaboom.md
@@ -2,7 +2,7 @@
 
 Snake was an incredibly popular game, mostly remembered from 1990s era cell phones. At the time, it was often the only game you'd find on a phone. In the most basic form, it's a super simple game, but still wildly entertaining. It's also a great game to build when you are learning the basics of game making.
 
-In this tutorial, we'll implement Snake using [Kaboom.js](https://kaboomjs.com) built into [Replit](https://replit.com) 
+In this tutorial, we'll implement Snake using [Kaboom.js](https://kaboomjs.com) built into [Replit](https://replit.com)
 
 <img src="/images/tutorials/21-snake-kaboom/updated-graphic.gif"
      alt="game functionality"
@@ -11,7 +11,7 @@ In this tutorial, we'll implement Snake using [Kaboom.js](https://kaboomjs.com) 
 
 ## Overview and Requirements
 
-We'll use the [Replit](https://replit.com) web IDE to create our version of Snake. If you don't already have a Replit account, [create one now](https://replit.com/signup). 
+We'll use the [Replit](https://replit.com) web IDE to create our version of Snake. If you don't already have a Replit account, [create one now](https://replit.com/signup).
 
 Let's think a bit about what we need to do. Snake, at its core, is a series of blocks representing a snake moving around a grid, with the player controlling the direction. It also has simple rules – when the snake touches the sides of the screen, it dies. If the snake crosses itself, it also dies. If the snake eats some food (a different type of block), it grows by 1 block. The food then re-appears at another random place on the screen.
 
@@ -36,17 +36,17 @@ After the repl has booted up, you should see a `main.js` file under the "Scenes"
 
 ## Getting Started with Kaboom.js
 
-[Kaboom.js](https://kaboomjs.com) is a JavaScript library that contains many useful features to make simple in-browser games. It has functionality to draw shapes and sprites (the images of characters and game elements) to the screen, get user input, play sounds, and more. We'll explore these features and learn how they work by using some of them in our game. 
+[Kaboom.js](https://kaboomjs.com) is a JavaScript library that contains many useful features to make simple in-browser games. It has functionality to draw shapes and sprites (the images of characters and game elements) to the screen, get user input, play sounds, and more. We'll explore these features and learn how they work by using some of them in our game.
 
-Kaboom.js also makes good use of JavaScript's support for [callbacks](https://developer.mozilla.org/en-US/docs/Glossary/Callback_function); instead of writing loops to read in keyboard input and check if game objects have collided (bumped into each other), Kaboom.js uses an event model, where it tells us when such an event has occurred. Then we can connect up [callback functions](https://developer.mozilla.org/en-US/docs/Glossary/Callback_function) that act on these events. 
+Kaboom.js also makes good use of JavaScript's support for [callbacks](https://developer.mozilla.org/en-US/docs/Glossary/Callback_function); instead of writing loops to read in keyboard input and check if game objects have collided (bumped into each other), Kaboom.js uses an event model, where it tells us when such an event has occurred. Then we can connect up [callback functions](https://developer.mozilla.org/en-US/docs/Glossary/Callback_function) that act on these events.
 
-Using Kaboom.js in Replit takes care of all the boilerplate initialisation code, as well as asset loading, so we can concentrate on writing the game logic and making game graphics and sound. 
+Using Kaboom.js in Replit takes care of all the boilerplate initialisation code, as well as asset loading, so we can concentrate on writing the game logic and making game graphics and sound.
 
 ## Creating the Game Map
 
 To start, we can get our game board, or _map_ drawn on the screen. This will define the edges of the board so that if the snake crashes into them, we can detect and end the game.
 
-Kaboom.js has built-in support for defining game maps, using a text array and the function [`addLevel`](https://kaboomjs.com/doc#addLevel). This takes away a lot of the hassle normally involved in loading and rendering maps. 
+Kaboom.js has built-in support for defining game maps, using a text array and the function [`addLevel`](https://kaboomjs.com/doc#addLevel). This takes away a lot of the hassle normally involved in loading and rendering maps.
 
 Replace the example code in `main.js` file with the following to create the game board:
 
@@ -55,7 +55,7 @@ import kaboom from "kaboom";
 
 kaboom();
 
-const block_size = 20; 
+const block_size = 20;
 
 const map = addLevel([
     "==============",
@@ -79,7 +79,7 @@ const map = addLevel([
   "=": () => [
     rect(block_size, block_size),
     color(255,0,0),
-    area(),      
+    area(),
     "wall"
   ]
 });
@@ -87,19 +87,19 @@ const map = addLevel([
 
 On the first line we import the kaboom library, and then initialize the context by calling `kaboom()`. This will give us a blank canvas with a nice checkerboard pattern. We then create a constant for the size of each block on our grid. This is just so we don't need to keep typing in the number, and also helps if we want to experiment later with different block sizes etc.
 
-Then we create the game map. The map, or level design, is expressed in an array of strings. Each row in the array represents one row on the screen. So, we can design visually in text what the map should look like. The `width` and `height` parameters specify the size of each of the elements in the map. The `pos` parameter specifies where on the screen the map should be place – we choose `(0,0)`, which is the top left of the screen, as the starting point for the map. 
+Then we create the game map. The map, or level design, is expressed in an array of strings. Each row in the array represents one row on the screen. So, we can design visually in text what the map should look like. The `width` and `height` parameters specify the size of each of the elements in the map. The `pos` parameter specifies where on the screen the map should be place – we choose `(0,0)`, which is the top left of the screen, as the starting point for the map.
 
 Then Kaboom.js allows us to specify what to draw for each symbol in the text map. We're only using one symbol here, `=`, but you can make maps out of many different elements – e.g., a symbol for a wall, a symbol for water, a symbol for a health kit and so on. To tell Kaboom.js what to draw for the symbol, we add the symbol as a key, as in `=`, and then specify parameters for it. In this code, we draw a red rectangle as each piece of the boundary wall. The `area()` component generates the collision area which will be useful when we want to check for collision between the snake and wall later on. The string `wall` assigns a tag to each of the pieces of wall drawn, which will also help us with collision detection later on.
 
-If we run this code, we should see the outline of a red square on the screen, representing the map. 
+If we run this code, we should see the outline of a red square on the screen, representing the map.
 
 <img src="/images/tutorials/21-snake-kaboom/boundary-wall.png"
      alt="Boundary wall from map"
      style="width: 650px !important;"/>
 
-## Adding the Snake 
+## Adding the Snake
 
-Now that we have a map, let's add the snake. The snake is made up of a number of blocks moving together. We'll need to keep track of these so that we can move them together, so an [array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array) would be a good data structure to use here. 
+Now that we have a map, let's add the snake. The snake is made up of a number of blocks moving together. We'll need to keep track of these so that we can move them together, so an [array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array) would be a good data structure to use here.
 
 We also need to start the snake off with a given size, position and direction to move in on the map. It can return to these each time the game ends as well. So we should make a function that we can call whenever a new game starts, or the old one ends, to reset the snake to a default position and size.
 
@@ -107,31 +107,31 @@ We'll need to add a few variables and constants that our snake drawing function 
 
 ```javascript
 const directions = {
-  UP: "up", 
-  DOWN: "down", 
-  LEFT: "left", 
+  UP: "up",
+  DOWN: "down",
+  LEFT: "left",
   RIGHT: "right"
 };
 
-let current_direction = directions.RIGHT; 
+let current_direction = directions.RIGHT;
 let run_action = false;
-let snake_length = 3; 
-let snake_body = []; 
+let snake_length = 3;
+let snake_body = [];
 
 ```
 
-First, we define an object with properties for each of the allowable directions the snake can move in. This makes code that checks and changes directions easy to read and change, compared to just using numbers or strings to define the directions. The variable `current_direction` tracks the direction the snake is moving at any given time. We choose a starting direction, `RIGHT`, as its default. `run_action` is a flag variable that we'll use to flag if we are in the actual game, or setting up, or ending the game. The variable `snake_length` keeps track of how long the snake tail has become – we start it at a chosen value of 3. Finally, `snake_body` holds all the screen objects that make up the snake's body. 
+First, we define an object with properties for each of the allowable directions the snake can move in. This makes code that checks and changes directions easy to read and change, compared to just using numbers or strings to define the directions. The variable `current_direction` tracks the direction the snake is moving at any given time. We choose a starting direction, `RIGHT`, as its default. `run_action` is a flag variable that we'll use to flag if we are in the actual game, or setting up, or ending the game. The variable `snake_length` keeps track of how long the snake tail has become – we start it at a chosen value of 3. Finally, `snake_body` holds all the screen objects that make up the snake's body.
 
-Now we can add a function to spawn, and respawn, the snake. 
+Now we can add a function to spawn, and respawn, the snake.
 
-Let's add this function: 
+Let's add this function:
 
 ```javascript
 function respawn_snake(){
   destroyAll("snake");
 
   snake_body = [];
-  snake_length = 3; 
+  snake_length = 3;
 
   for (let i = 1; i <= snake_length; i++) {
       let segment = add([
@@ -140,34 +140,34 @@ function respawn_snake(){
           color(0,0,255),
           area(),
           "snake"
-      ]);  
-      snake_body.push(segment);  
-  }; 
-  current_direction = directions.RIGHT;  
+      ]);
+      snake_body.push(segment);
+  };
+  current_direction = directions.RIGHT;
 }
 
 function respawn_all(){
-  run_action = false; 
+  run_action = false;
     wait(0.5, function(){
-        respawn_snake(); 
-        run_action = true; 
-    }); 
- 
+        respawn_snake();
+        run_action = true;
+    });
+
 }
 
-respawn_all(); 
+respawn_all();
 
 ```
 
-First, the function gets rid of any existing snake segment objects by using the Kaboom.js [`destroyAll` function](https://kaboomjs.com/doc#destroyAll). This removes any object with the given tag from the game. Then we reset our segment array to an empty array, and the snake length back to the default. 
+First, the function gets rid of any existing snake segment objects by using the Kaboom.js [`destroyAll` function](https://kaboomjs.com/doc#destroyAll). This removes any object with the given tag from the game. Then we reset our segment array to an empty array, and the snake length back to the default.
 
-Then the function sets up a loop to create new snake segments, up to the length we specified. It does this by calling the Kaboom.js [`add`](https://kaboomjs.com/doc#add) method, which adds a new object to the game. `add` takes a few parameters, as components of the object to create. We pass in components to specify how to draw the object (using [`rect`](https://kaboomjs.com/doc#rect)), its color, and a tag "snake" to identify the segments when we are checking collisions, and updating/removing segments. We also specify the position for the segment we create. To create the starting snake, we just ensure it is at least one `block_size`, or block, from the left side, and then add each subsequent segment one more block down per loop. This gives a straight snake pointing down to start. Then we add the new segment to our `snake_body` array to keep track of it. 
+Then the function sets up a loop to create new snake segments, up to the length we specified. It does this by calling the Kaboom.js [`add`](https://kaboomjs.com/doc#add) method, which adds a new object to the game. `add` takes a few parameters, as components of the object to create. We pass in components to specify how to draw the object (using [`rect`](https://kaboomjs.com/doc#rect)), its color, and a tag "snake" to identify the segments when we are checking collisions, and updating/removing segments. We also specify the position for the segment we create. To create the starting snake, we just ensure it is at least one `block_size`, or block, from the left side, and then add each subsequent segment one more block down per loop. This gives a straight snake pointing down to start. Then we add the new segment to our `snake_body` array to keep track of it.
 
-Finally, we set a default starting direction for the snake to move in. 
+Finally, we set a default starting direction for the snake to move in.
 
-You'll notice that we also add in a function `respawn_all`, and a call to the function `respawn_snake`. We'll use the `respawn_all` function to call all of our other respawn functions. Currently we have one for the snake, but we'll also need one for the food when we add it. In the `respawn_all` function, we also take care to set the `run_action` flag to false, so that no updates are made while we are setting up or resetting objects. We also wrap the calls in a Kaboom.js [`wait` function](https://kaboomjs.com/doc#wait), with a small delay of 0.5 seconds. This is because when we detect a "game over" condition, we don't immediately want to reset the game, as it could be a bit disorienting to a player. 
+You'll notice that we also add in a function `respawn_all`, and a call to the function `respawn_snake`. We'll use the `respawn_all` function to call all of our other respawn functions. Currently we have one for the snake, but we'll also need one for the food when we add it. In the `respawn_all` function, we also take care to set the `run_action` flag to false, so that no updates are made while we are setting up or resetting objects. We also wrap the calls in a Kaboom.js [`wait` function](https://kaboomjs.com/doc#wait), with a small delay of 0.5 seconds. This is because when we detect a "game over" condition, we don't immediately want to reset the game, as it could be a bit disorienting to a player.
 
-Running the code now, you should see a blue line at the top-left side of the map. 
+Running the code now, you should see a blue line at the top-left side of the map.
 
 <img src="/images/tutorials/21-snake-kaboom/static-snake.png"
      alt="static snake"
@@ -176,78 +176,78 @@ Running the code now, you should see a blue line at the top-left side of the map
 
 ## Moving the Snake
 
-Now that we've got map boundaries, and a snake drawn on the screen, we can work on getting player input and moving the snake around. 
+Now that we've got map boundaries, and a snake drawn on the screen, we can work on getting player input and moving the snake around.
 
-Kaboom.js has a function [`keypress`](https://kaboomjs.com/doc#keyPress), which can call a supplied function whenever a particular key is pressed. We'll use that to determine which way the player wants the snake to go. Add this code to get user direction input: 
+Kaboom.js has a function [`onKeyPress`](https://kaboomjs.com/doc#onKeyPress), which can call a supplied function whenever a particular key is pressed. We'll use that to determine which way the player wants the snake to go. Add this code to get user direction input:
 
 ```javascript
-keyPress("up", () => {
+onKeyPress("up", () => {
     if (current_direction != directions.DOWN){
-        current_direction = directions.UP; 
+        current_direction = directions.UP;
     }
 });
 
-keyPress("down", () => {
+onKeyPress("down", () => {
     if (current_direction != directions.UP){
-        current_direction = directions.DOWN; 
+        current_direction = directions.DOWN;
     }
 });
 
-keyPress("left", () => {
+onKeyPress("left", () => {
     if (current_direction != directions.RIGHT){
-        current_direction = directions.LEFT; 
+        current_direction = directions.LEFT;
     }
 });
 
-keyPress("right", () => {
+onKeyPress("right", () => {
     if (current_direction != directions.LEFT){
-        current_direction = directions.RIGHT; 
+        current_direction = directions.RIGHT;
     }
 });
 
 ```
 
-For each of the named "arrow" keys, we set up a function to call if the key is pressed. In each of these functions, we check to ensure that the new direction input is not the complete opposite direction to which the snake is currently moving. This is because we don't want to allow the snake to reverse. If the input direction is a legal move, we update the `current_direction` property to the new direction. 
+For each of the named "arrow" keys, we set up a function to call if the key is pressed. In each of these functions, we check to ensure that the new direction input is not the complete opposite direction to which the snake is currently moving. This is because we don't want to allow the snake to reverse. If the input direction is a legal move, we update the `current_direction` property to the new direction.
 
-Now we need to think about how to make the snake appear to move on the screen. A way to do this is to check which direction the snake is heading, and add a block in front of the snake in that direction. Then we'll need to remove a block at the tail-end of the snake. We'll need to do this a few times in a second so that the snake appears to be moving smoothly. Kaboom.js has a function [`action`](https://kaboomjs.com/doc#action) which can be used to update game objects on each frame. Add the following code, which uses the `action` function, to move the snake: 
+Now we need to think about how to make the snake appear to move on the screen. A way to do this is to check which direction the snake is heading, and add a block in front of the snake in that direction. Then we'll need to remove a block at the tail-end of the snake. We'll need to do this a few times in a second so that the snake appears to be moving smoothly. Kaboom.js has a function [`onUpdate`](https://kaboomjs.com/doc#onUpdate) which can be used to update game objects on each frame. Add the following code, which uses the `onUpdate` function, to move the snake:
 
 ```javascript
 
 let move_delay = 0.2;
 let timer = 0;
-action(()=> {
+onUpdate(()=> {
      if (!run_action) return;
      timer += dt();
      if (timer < move_delay) return;
      timer = 0;
 
     let move_x = 0;
-    let move_y = 0; 
+    let move_y = 0;
 
     switch (current_direction) {
         case directions.DOWN:
-            move_x = 0; 
-            move_y = block_size; 
+            move_x = 0;
+            move_y = block_size;
             break;
         case directions.UP:
             move_x = 0;
-            move_y = -1*block_size; 
+            move_y = -1*block_size;
             break;
         case directions.LEFT:
             move_x = -1*block_size;
-            move_y = 0; 
+            move_y = 0;
             break;
         case directions.RIGHT:
             move_x = block_size;
-            move_y = 0; 
-            break;          
+            move_y = 0;
+            break;
     }
 
     // Get the last element (the snake head)
-    let snake_head = snake_body[snake_body.length - 1]; 
+    let snake_head = snake_body[snake_body.length - 1];
 
     snake_body.push(add([
-        rect(block_size,block_size), 
+        rect(block_size,block_size),
         pos(snake_head.pos.x + move_x, snake_head.pos.y + move_y),
         color(0,0,255),
         area(),
@@ -256,22 +256,22 @@ action(()=> {
 
     if (snake_body.length > snake_length){
         let tail = snake_body.shift(); // Remove the last of the tail
-        destroy(tail); 
+        destroy(tail);
     }
 
-}); 
+});
 
 ```
 
-We set the action to run every 0.2 seconds, or 5 times a second to get smooth movement. Since the `action` function updates game objects on each frame we use the [`dt()` function](https://kaboomjs.com/doc#dt) to get the time that has elapsed between the previous and current frame, so that we can keep track if 0.2 seconds has elapsed for us to move the snake. If the desired delay has not elapsed we exit early without updating anything otherwise we reset the timer and execute the code to move the snake.  You can try experiment with different times to see the effect on the game by adjusting the value of the `move_delay` variable. We also check the flag variable `run_action` we defined earlier – if it is false, we exit early without updating anything. Then, the function defines 2 local variables, `move_x` and `move_y`, which is used to determine where to place the 'next' block relative to the head of the snake. 
+We set the action to run every 0.2 seconds, or 5 times a second to get smooth movement. Since the `action` function updates game objects on each frame we use the [`dt()` function](https://kaboomjs.com/doc#dt) to get the time that has elapsed between the previous and current frame, so that we can keep track if 0.2 seconds has elapsed for us to move the snake. If the desired delay has not elapsed we exit early without updating anything otherwise we reset the timer and execute the code to move the snake.  You can try experiment with different times to see the effect on the game by adjusting the value of the `move_delay` variable. We also check the flag variable `run_action` we defined earlier – if it is false, we exit early without updating anything. Then, the function defines 2 local variables, `move_x` and `move_y`, which is used to determine where to place the 'next' block relative to the head of the snake.
 
-Then the function switches on the value of the current direction the snake is heading in. For each direction, the `move_x` and `move_y` are set to either 0, block_size or -1 * block_size. If the snake is moving left or right, we add or subtract a block from the x dimension accordingly. The same occurs if the snake is moving up or down, but in the y dimension. 
+Then the function switches on the value of the current direction the snake is heading in. For each direction, the `move_x` and `move_y` are set to either 0, block_size or -1 * block_size. If the snake is moving left or right, we add or subtract a block from the x dimension accordingly. The same occurs if the snake is moving up or down, but in the y dimension.
 
-After the switch, we get the current snake head by indexing the last element in the snake body array. Now that we have both the current snake head position, and the position amount relative to the snake head to move in, we can create the new snake head by adding a new block game object. This is similar to the code we used in `respawn_snake`. 
+After the switch, we get the current snake head by indexing the last element in the snake body array. Now that we have both the current snake head position, and the position amount relative to the snake head to move in, we can create the new snake head by adding a new block game object. This is similar to the code we used in `respawn_snake`.
 
-Now all that remains is to remove a block at the tail end of the snake, using the built-in array [`shift` function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/shift), which removes the first element from an array, and returns that element. Because our 'oldest' part of the snake, also known as a tail, is the first element, we call shift on the array, and then the Kaboom.js [`destroy` function](https://kaboomjs.com/doc#destroy) to get rid of the segment. We only do this if the current length of the snake body array is greater than our determined snake length. This means if we increase `snake_length`, the overall length of the snake on the screen will also increase. We can use this when we add food to the game. 
+Now all that remains is to remove a block at the tail end of the snake, using the built-in array [`shift` function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/shift), which removes the first element from an array, and returns that element. Because our 'oldest' part of the snake, also known as a tail, is the first element, we call shift on the array, and then the Kaboom.js [`destroy` function](https://kaboomjs.com/doc#destroy) to get rid of the segment. We only do this if the current length of the snake body array is greater than our determined snake length. This means if we increase `snake_length`, the overall length of the snake on the screen will also increase. We can use this when we add food to the game.
 
-Running the project now and clicking into the game screen should allow you to move the snake around. Note that there isn't collision detection yet, so the snake can go out of bounds without consequence. 
+Running the project now and clicking into the game screen should allow you to move the snake around. Note that there isn't collision detection yet, so the snake can go out of bounds without consequence.
 
 ![Moving the snake](/images/tutorials/21-snake-kaboom/snake-move.gif)
 
@@ -281,16 +281,16 @@ Running the project now and clicking into the game screen should allow you to mo
 We have a snake, it moves, and a player can steer it. Let's add some food that the snake can eat, which will cause it to grow longer. Whenever the snake eats the food, we'll have to respawn the food again, so let's write the food creation code in a function as well, like we did for the snake:
 
 ```javascript
-let food = null; 
+let food = null;
 
 function respawn_food(){
     let new_pos = rand(vec2(1,1), vec2(13,13));
-    new_pos.x = Math.floor(new_pos.x); 
-    new_pos.y = Math.floor(new_pos.y); 
+    new_pos.x = Math.floor(new_pos.x);
+    new_pos.y = Math.floor(new_pos.y);
     new_pos = new_pos.scale(block_size);
 
     if (food){
-        destroy(food); 
+        destroy(food);
     }
     food = add([
                 rect(block_size ,block_size),
@@ -298,33 +298,33 @@ function respawn_food(){
                 pos(new_pos),
                 area(),
                 "food"
-            ]); 
+            ]);
 }
 
 ```
 
 Firstly, we set up a variable `food` so that we can keep track of food objects we create. You can move this variable up to where we declared other variables, like `block_size` and `snake_body` if you want to keep them all neatly in the same place.
 
-Then the function `respawn_food` does a few things. In the game of snake, once a food block is eaten, another one appears at a random location on the grid. This means we'll need a random number generator to determine the location to place the food. Kaboom.js has a function called [`rand`](https://kaboomjs.com/doc#rand) which we can use to find a random position on the screen to place the food. We need both random `x` and `y` co-ordinates – conveniently, the `rand` function can accept 2D vectors as the start and end amount for the random range to generate numbers in, and will then return another 2D vector as a result. 
+Then the function `respawn_food` does a few things. In the game of snake, once a food block is eaten, another one appears at a random location on the grid. This means we'll need a random number generator to determine the location to place the food. Kaboom.js has a function called [`rand`](https://kaboomjs.com/doc#rand) which we can use to find a random position on the screen to place the food. We need both random `x` and `y` co-ordinates – conveniently, the `rand` function can accept 2D vectors as the start and end amount for the random range to generate numbers in, and will then return another 2D vector as a result.
 
-Why do we choose a range of 1-13 for the random position of the food? If you look at the map we added earlier, it is 14 spaces across and 14 spaces down. These are the dimensions of our screen in grid blocks. Because we don't want to draw the food over the boundaries, we use 1-13 to choose blocks within the map. Now, the `rand` function returns real numbers, with decimals, not integers. This means we need to add the `Math.floor` call to truncate any decimals off the random numbers, as we don't want to place the food halfway through a particular grid block. We also need to convert from our grid co-ordinates to regular screen pixels. This is done by multiplying each co-ordinate by the `block_size`, which specifies the size of each grid block in pixels. We make use of the Kaboom.js [`scale` method](https://kaboomjs.com/doc#vec2) on the `vec2` class to perform the multiplication. 
+Why do we choose a range of 1-13 for the random position of the food? If you look at the map we added earlier, it is 14 spaces across and 14 spaces down. These are the dimensions of our screen in grid blocks. Because we don't want to draw the food over the boundaries, we use 1-13 to choose blocks within the map. Now, the `rand` function returns real numbers, with decimals, not integers. This means we need to add the `Math.floor` call to truncate any decimals off the random numbers, as we don't want to place the food halfway through a particular grid block. We also need to convert from our grid co-ordinates to regular screen pixels. This is done by multiplying each co-ordinate by the `block_size`, which specifies the size of each grid block in pixels. We make use of the Kaboom.js [`scale` method](https://kaboomjs.com/doc#vec2) on the `vec2` class to perform the multiplication.
 
-The next part of the function checks if the `food` variable already contains an existing food object. If it does, we call [`destroy`](https://kaboomjs.com/doc#destroy) to remove that food from the game. Finally, the function creates a new food object by calling the Kaboom.js [`add`](https://kaboomjs.com/doc#add) function to create a new food object at the random position we made.  
+The next part of the function checks if the `food` variable already contains an existing food object. If it does, we call [`destroy`](https://kaboomjs.com/doc#destroy) to remove that food from the game. Finally, the function creates a new food object by calling the Kaboom.js [`add`](https://kaboomjs.com/doc#add) function to create a new food object at the random position we made.
 
 To call this new `respawn_food` function, we need to update our `respawn_all` function, like this:
 
 ```javascript
 function respawn_all(){
-  run_action = false; 
+  run_action = false;
     wait(0.5, function(){
-        respawn_snake(); 
+        respawn_snake();
         respawn_food();
-        run_action = true; 
-    }); 
+        run_action = true;
+    });
 }
 ```
 
-Running the game now shows a green food block positioned somewhere randomly on the map: 
+Running the game now shows a green food block positioned somewhere randomly on the map:
 
 <img src="/images/tutorials/21-snake-kaboom/food-added.png"
      alt="food added"
@@ -332,20 +332,20 @@ Running the game now shows a green food block positioned somewhere randomly on t
 
 ## Detecting Collisions
 
-Now that we have all the objects our game needs – a boundary wall, a snake, and food – we can move on to detecting interactions, or collisions, between these objects. 
+Now that we have all the objects our game needs – a boundary wall, a snake, and food – we can move on to detecting interactions, or collisions, between these objects.
 
-Kaboom.js has a useful function for helping with this: [`collides`](https://kaboomjs.com/doc#collides). The function takes in 2 tags for different game object types, and calls a provided callback function if there is a collision of the objects.
+Kaboom.js has a useful function for helping with this: [`onCollide`](https://kaboomjs.com/doc#onCollide). The function takes in 2 tags for different game object types, and calls a provided callback function if there is a collision of the objects.
 
-Let's start with detecting if the snake moves over a food block. Add the code below: 
+Let's start with detecting if the snake moves over a food block. Add the code below:
 
 ```javascript
-collides("snake", "food", (s, f) => {
-    snake_length ++; 
+onCollide("snake", "food", (s, f) => {
+    snake_length ++;
     respawn_food();
 });
 ```
 
-We set up the `collides` function with tags for the snake, and the food object. Then, in the callback function, `snake_length` is increased by 1, and we call `respawn_food` to replace the eaten food somewhere else on the map. 
+We set up the `onCollide` function with tags for the snake, and the food object. Then, in the callback function, `snake_length` is increased by 1, and we call `respawn_food` to replace the eaten food somewhere else on the map.
 
 Running this, and eating the food, you should see the snake grow each time, and the food re-appear on another block:
 
@@ -353,24 +353,24 @@ Running this, and eating the food, you should see the snake grow each time, and 
      alt="eating food"
      style="width: 650px !important;"/>
 
-Now, we can add similar code to detect if the snake has hit the wall: 
+Now, we can add similar code to detect if the snake has hit the wall:
 
 ```javascript
-collides("snake", "wall", (s, w) => {
-    run_action = false; 
+onCollide("snake", "wall", (s, w) => {
+    run_action = false;
     shake(12);
-    respawn_all(); 
+    respawn_all();
 });
 ```
-In the callback function, we immediately set the `run_action` flag to false. This is so that the code in the move loop does not run and create the appearance of the snake stuck in the wall. Then the code calls a cool Kaboom.js effect function [`shake`](https://kaboomjs.com/doc#shake), which "shakes" the screen in a way that makes it feel like the snake has crashed heavily, and communicates quite effectively that the game is over. Finally, we call `respawn_all` to reset all the game objects. 
+In the callback function, we immediately set the `run_action` flag to false. This is so that the code in the move loop does not run and create the appearance of the snake stuck in the wall. Then the code calls a cool Kaboom.js effect function [`shake`](https://kaboomjs.com/doc#shake), which "shakes" the screen in a way that makes it feel like the snake has crashed heavily, and communicates quite effectively that the game is over. Finally, we call `respawn_all` to reset all the game objects.
 
-We can use the same code to detect if the snake has hit itself – we just replace the `wall` tag with another `snake` tag: 
+We can use the same code to detect if the snake has hit itself – we just replace the `wall` tag with another `snake` tag:
 
 ```javascript
-collides("snake", "snake", (s, t) => {
-    run_action = false; 
+onCollide("snake", "snake", (s, t) => {
+    run_action = false;
     shake(12);
-    respawn_all(); 
+    respawn_all();
 });
 ```
 
@@ -381,14 +381,14 @@ Running the game now, and crashing into the wall should look something like this
      style="width: 650px !important;"/>
 
 
-Congratulations! You've finished creating Snake in Kaboom.js! 
+Congratulations! You've finished creating Snake in Kaboom.js!
 
 
 ## Improving the Graphics
 
-We have a working snake game, but it does look a bit bland. Kaboom.js has good support for [_sprites_](https://en.wikipedia.org/wiki/Sprite_%28computer_graphics%29), which are small pictures used to represent game objects and characters. Replit also has built-in management and loading of sprites for Kaboom.js to take care of the overhead in using sprites. 
+We have a working snake game, but it does look a bit bland. Kaboom.js has good support for [_sprites_](https://en.wikipedia.org/wiki/Sprite_%28computer_graphics%29), which are small pictures used to represent game objects and characters. Replit also has built-in management and loading of sprites for Kaboom.js to take care of the overhead in using sprites.
 
-Using sprites, let's give the snake something nicer to eat than a green block. Right click and select "Save image as" on the pizza slice below, and save it to your computer. Then, in Replit, click the upload button next to "Sprites" and upload the pizza to your repl. 
+Using sprites, let's give the snake something nicer to eat than a green block. Right click and select "Save image as" on the pizza slice below, and save it to your computer. Then, in Replit, click the upload button next to "Sprites" and upload the pizza to your repl.
 
 
 <img src="/images/tutorials/21-snake-kaboom/pizza.png"
@@ -403,44 +403,44 @@ Now, we can update the `respawn_food` function to use this sprite, instead of dr
 ```javascript
 function respawn_food(){
     let new_pos = rand(vec2(1,1), vec2(13,13));
-    new_pos.x = Math.floor(new_pos.x); 
-    new_pos.y = Math.floor(new_pos.y); 
+    new_pos.x = Math.floor(new_pos.x);
+    new_pos.y = Math.floor(new_pos.y);
     new_pos = new_pos.scale(block_size);
 
     if (food){
-        destroy(food); 
+        destroy(food);
     }
     food = add([
                 sprite('pizza'),
                 pos(new_pos),
                 area(),
                 "food"
-            ]); 
+            ]);
 }
 ```
 
-We can also update the background to be more interesting. To do this, we can make use of Kaboom.js' [layers](https://kaboomjs.com/doc#layers) concept. This allows us to create different graphic layers, for example one for a static background image, another one for the active game objects over that, and another top layer for stats and scores etc. 
+We can also update the background to be more interesting. To do this, we can make use of Kaboom.js' [layers](https://kaboomjs.com/doc#layers) concept. This allows us to create different graphic layers, for example one for a static background image, another one for the active game objects over that, and another top layer for stats and scores etc.
 
 We'll create 2 layers, background and game, to support a background. Download and add the background grass image below to your repl as you did for the pizza slice:
 
 ![background](/images/tutorials/21-snake-kaboom/background.png)
 
-Now, we can set up the layers and add the background grass. Add the following code to the top of the `main` file: 
+Now, we can set up the layers and add the background grass. Add the following code to the top of the `main` file:
 
 ```javascript
 layers([
-    "background", 
+    "background",
     "game"
-], "game"); 
+], "game");
 
 add([
-    sprite("background"), 
+    sprite("background"),
     layer("background")
-]); 
+]);
 
 ```
 
-This sets up our 2 layers, and makes the `game` layer the default layer to draw on. Whenever we call [`add`](https://kaboomjs.com/doc#add), we can optionally specify a layer to put the object on – if we don't specify a layer, it uses whatever we set as default in the call to [`layers`](https://kaboomjs.com/doc#layers). Then we add our background sprite to the background layer. 
+This sets up our 2 layers, and makes the `game` layer the default layer to draw on. Whenever we call [`add`](https://kaboomjs.com/doc#add), we can optionally specify a layer to put the object on – if we don't specify a layer, it uses whatever we set as default in the call to [`layers`](https://kaboomjs.com/doc#layers). Then we add our background sprite to the background layer.
 
 Next, we can update the boundaries to look a bit better. Recall that in our map we add with [`addLevel`](https://kaboomjs.com/doc#addLevel), each different symbol we use can map to a different game object. Using this, we can create a good looking border fence, with different elements for each side and corners. Download the following 8 sprites as before, and upload them to your repl:
 
@@ -476,7 +476,7 @@ Next, we can update the boundaries to look a bit better. Recall that in our map 
      alt="post top right"
      style="width: 50px !important;"/>
 
-Now, we can update the level map to use these. Replace the previous `addLevel` code with the following code: 
+Now, we can update the level map to use these. Replace the previous `addLevel` code with the following code:
 
 ```javascript
 const map = addLevel([
@@ -545,8 +545,8 @@ const map = addLevel([
 The last thing is to upgrade the snake itself. Download the skin below, and upload to the repl as before.
 
 
-<img src="/images/tutorials/21-snake-kaboom/snake-skin.png" 
-     alt="snake skin" 
+<img src="/images/tutorials/21-snake-kaboom/snake-skin.png"
+     alt="snake skin"
      style="width: 50px !important;"/>
 
 
@@ -555,20 +555,20 @@ We create snake pieces in 2 places: in the `respawn_snake` function, and in the 
 ```javascript
 function respawn_snake(){
   snake_body.forEach(segment => {
-      destroy(segment); 
+      destroy(segment);
     });
   snake_body = [];
-  snake_length = 3; 
+  snake_length = 3;
 
   for (let i = 1; i <= snake_length; i++) {
       snake_body.push(add([
-          sprite('snake-skin'), 
+          sprite('snake-skin'),
           pos(block_size  ,block_size * i),
           area(),
           "snake"
-      ]));   
+      ]));
   }
-  current_direction = directions.RIGHT;  
+  current_direction = directions.RIGHT;
 }
 
 ```
@@ -577,7 +577,7 @@ In the loop callback, the updated code for adding a new snake segment to the bod
 
 ```javascript
     snake_body.push(add([
-        sprite('snake-skin'),  
+        sprite('snake-skin'),
         pos(snake_head.pos.x + move_x, snake_head.pos.y + move_y),
         area(),
         "snake"
@@ -608,11 +608,11 @@ If you run the game now, you should see it looking much better!
 
 
 ## Things to Try
-There is a lot of good functionality in [Kaboom.js](https://kaboomjs.com/) to try out, and make the game more entertaining. Here are some suggestions: 
+There is a lot of good functionality in [Kaboom.js](https://kaboomjs.com/) to try out, and make the game more entertaining. Here are some suggestions:
 
 - Create a 2 player version.
 - Add obstacles for the snake.
-- Incrementally speed up the game as it goes on, to make it harder. You can do this by adjusting the delay parameter of the `loop` function as the game progresses. 
+- Incrementally speed up the game as it goes on, to make it harder. You can do this by adjusting the delay parameter of the `loop` function as the game progresses.
 - Add [sound effects](https://kaboomjs.com/doc#play) and background music.
 
 

--- a/tutorials/23-build-asteroids-with-kaboom.md
+++ b/tutorials/23-build-asteroids-with-kaboom.md
@@ -147,20 +147,20 @@ In this game, our player will turn the nose of the spaceship with the left and r
 
 ```javascript
 // Movement keys
-keyDown("left", () => {
+onKeyDown("left", () => {
     player.angle += player.turn_speed;
 });
-keyDown("right", () => {
+onKeyDown("right", () => {
     player.angle -= player.turn_speed;
 });
 ```
 
-Run your repl now, and you should be able to turn the ship to the left and right by pressing the respective arrow keys. If you think it turns too fast or too slow, change the value of `turn_speed` in the player creation code. 
+Run your repl now, and you should be able to turn the ship to the left and right by pressing the respective arrow keys. If you think it turns too fast or too slow, change the value of `turn_speed` in the player creation code.
 
 Now let's implement the up and down keys, so the player can move around the scene. Enter the following code beneath the player turning code:
 
 ```javascript
-keyDown("up", () => {
+onKeyDown("up", () => {
     player.speed = Math.min(player.speed+player.acceleration, player.max_thrust);
     play("rocket_thrust", {
         volume: 0.1,
@@ -176,7 +176,7 @@ Additionally, we set our rocket thrust sound to [play](https://kaboomjs.com/doc#
 We'll handle deceleration by doing the opposite to acceleration, using [Math.max()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/max) to choose the maximum between the player's speed minus their deceleration, and their maximum speed in reverse (i.e. negative). Add the following code below the acceleration controls:
 
 ```javascript
-keyDown("down", () => {
+onKeyDown("down", () => {
     player.speed = Math.max(player.speed-player.deceleration, -player.max_thrust);
     play("rocket_thrust", {
         volume: 0.2,
@@ -191,14 +191,14 @@ If you run your repl now and try to accelerate or decelerate, the sound will pla
 
 Movement in Kaboom and most other 2D game development systems is handled using X and Y coordinates on a plane. To move an object left, you subtract from its X coordinate, and to move it right, you add to its X coordinate. To move an object up, you subtract from its Y coordinate, and to move it down, you add to its Y coordinate. Therefore, basic four-directional movement in games like Snake or Pacman is quite straightforward. The directional movement we need for Asteroids (commonly called [tank controls](https://en.wikipedia.org/wiki/Tank_controls)) is more complex, requiring some calculations.
 
-At a high level, we want to move a given distance (`player.speed`) in a given direction (`player.angle`). As a first step, let's create an `action` callback for our `mobile` tag. This code, like our UI drawing code above, will be run by every object with the "mobile" tag on every frame of the game, so we can use it for more than just the player object. Add the following code at the bottom of your main scene:
+At a high level, we want to move a given distance (`player.speed`) in a given direction (`player.angle`). As a first step, let's create an `onUpdate` callback for our `mobile` tag. This code, like our UI drawing code above, will be run by every object with the "mobile" tag on every frame of the game, so we can use it for more than just the player object. Add the following code at the bottom of your main scene:
 
 ```javascript
 // Movement
-action("mobile", (e) => {
+onUpdate("mobile", (e) => {
     e.move(pointAt(e.speed, e.angle));
     e.resolve();
-});    
+});
 ```
 
 First, we move our object, using the function `pointAt()`, which takes a speed and an angle and returns the corresponding X and Y co-ordinates as a [`vec2`](https://kaboomjs.com/doc#vec2) object, Kaboom's 2D vector type. This data type is provided by Kaboom specifically for working with X and Y coordinates, and comes with a number of useful functions, such as addition and subtraction.
@@ -235,7 +235,7 @@ There's one little problem though: thrust too long, and you'll fly off the scree
 
 ```javascript
 // Wrap around the screen
-action("wraps", (e) => {
+onUpdate("wraps", (e) => {
     if (e.pos.x > width()) {
         e.pos.x = 0;
     }
@@ -266,15 +266,15 @@ First, let's create an array with our four rocket sprites. Add the following cod
 const thrust_animation = ["rocket1", "rocket2", "rocket3", "rocket4"];
 ```
 
-Then we need some way to indicate when to start and stop the animation. We can use Kaboom's [`keyPress`](https://kaboomjs.com/doc#keyPress) and [`keyRelease`](https://kaboomjs.com/doc#keyRelease) events for this, as well as two of the properties we defined for our player (`thrusting` and `animation_frame`). Add the following code:
+Then we need some way to indicate when to start and stop the animation. We can use Kaboom's [`onKeyPress`](https://kaboomjs.com/doc#onKeyPress) and [`onKeyRelease`](https://kaboomjs.com/doc#onKeyRelease) events for this, as well as two of the properties we defined for our player (`thrusting` and `animation_frame`). Add the following code:
 
 ```javascript
 // rocket animation helpers
-keyPress("up", () => {
+onKeyPress("up", () => {
     player.thrusting = true;
     player.animation_frame = 0;
 });
-keyRelease("up", () => {
+onKeyRelease("up", () => {
     player.thrusting = false;
 });
 ```
@@ -283,7 +283,7 @@ Now let's draw the animation. We'll use a draw event callback, which lets us mak
 
 ```javascript
 // draw current rocket animation frame
-on("draw", "player", (p) => {
+onDraw("player", (p) => {
     if (player.thrusting) {
         // draw current frame
         drawSprite(thrust_animation[p.animation_frame], {
@@ -321,7 +321,7 @@ To make our ship fire laser bullets, we need to create bullet objects just in fr
 
 ```javascript
 // Shooting
-keyDown("space", () => {
+onKeyDown("space", () => {
     add([
         sprite("bullet"),
         pos(player.pos.add(pointAt(player.width/2, player.angle))),
@@ -348,7 +348,7 @@ At the moment, a bullet object will be created in every frame while space is dow
 
 ```javascript
 // Shooting
-keyDown("space", () => {
+onKeyDown("space", () => {
     if (player.can_shoot) { // new if statement
         add([
             sprite("bullet"),
@@ -405,7 +405,7 @@ for (let i = 0; i < NUM_ASTERIODS; i++) {
             initializing: true
         }
     ]);
-    
+
     a.resolve();
 }
 ```
@@ -458,7 +458,7 @@ Let's go through the code for each of these, adding it to our main scene just be
 
 ```javascript
 // Collisions
-collides("player", "asteroid", (p, a) => {
+onCollide("player", "asteroid", (p, a) => {
     if (!a.initializing) {
         p.lives--;
     }
@@ -470,7 +470,7 @@ This code reduces the player's lives by one as long as the asteroid is not initi
 Next, add the code for collisions between a bullet and an asteroid:
 
 ```javascript
-collides("bullet", "asteroid", (b, a) => {
+onCollide("bullet", "asteroid", (b, a) => {
     if (!a.initializing) {
         destroy(b);
         destroy(a);
@@ -480,12 +480,12 @@ collides("bullet", "asteroid", (b, a) => {
 });
 ```
 
-This very simple code destroys both the bullet and the asteroid, plays an explosion sound, and increments the game score. 
+This very simple code destroys both the bullet and the asteroid, plays an explosion sound, and increments the game score.
 
-Finally, add the following to handle asteroid collisions. 
+Finally, add the following to handle asteroid collisions.
 
 ```javascript
-collides("asteroid", "asteroid", (a1, a2) => {
+onCollide("asteroid", "asteroid", (a1, a2) => {
     if (!(a1.initializing || a2.initializing)) {
         a1.speed = -a1.speed;
         a2.speed = -a2.speed;
@@ -505,7 +505,7 @@ The player's ship can now lose lives by crashing into asteroids, but this doesn'
 
 ```javascript
 // Collisions
-collides("player", "asteroid", (p, a) => {
+onCollide("player", "asteroid", (p, a) => {
     if (!a.initializing) {
         p.trigger("damage"); // previously lives--
     }
@@ -543,7 +543,7 @@ We need to give the player a way to restart the game and try again. Add the foll
 
 ```javascript
 // Restart game
-keyPress("r", () => {
+onKeyPress("r", () => {
     go("main");
 });
 ```
@@ -569,7 +569,7 @@ ui.on("draw", () => {
             origin: "center",
             scale: 0.5
         });
-    } 
+    }
 });
 ```
 
@@ -582,7 +582,7 @@ This code draws a number of scaled down player spaceships equal to the number of
 Our game is fully playable now, but it's still missing some niceties, and one core gameplay feature that you should be able to identify if you've played *Asteroids* before. In this final section, we'll add the following:
 
 * Some background music.
-* Smaller, faster asteroids that our large asteroids break into when destroyed. 
+* Smaller, faster asteroids that our large asteroids break into when destroyed.
 * Temporary invulnerability for the player for a few seconds after they take damage.
 
 ### Background music
@@ -613,7 +613,7 @@ on("destroy", "asteroid", (a) => {
 
         // small asteroids move out from the center of the explosion
         rotations = [0.6,2.4,4,5.4];
-    
+
         for (let i = 0; i < positions.length; i++) {
             add([
                 sprite(`asteroid_small${i+1}`),
@@ -640,7 +640,7 @@ Our small asteroids are mostly similar to our large ones. Differences include th
 To make our game true to the original *Asteroids*, we should give the player more points for destroying these fast, small asteroids. Find and modify the bullet–asteroid collision code as below:
 
 ```javascript
-collides("bullet", "asteroid", (b, a) => {
+onCollide("bullet", "asteroid", (b, a) => {
     if (!a.initializing) {
         destroy(b);
         destroy(a);
@@ -661,7 +661,7 @@ A nice touch to make our game a little more forgiving is temporary invulnerabili
 player.on("damage", () => {
     if (!player.invulnerable) { // new if statement
         player.lives--;
-    }    
+    }
 
     // destroy ship if lives finished
     if (player.lives <= 0) {
@@ -671,7 +671,7 @@ player.on("damage", () => {
     {
         // Temporary invulnerability
         player.invulnerable = true;
-    
+
         wait(player.invulnerablity_time, () => {
             player.invulnerable = false;
             player.hidden = false;

--- a/tutorials/24-build-space-shooter-with-kaboom.md
+++ b/tutorials/24-build-space-shooter-with-kaboom.md
@@ -14,7 +14,7 @@ You can download this [zip file](/tutorial-files/space-shooter-kaboom/space-shoo
 Here's what we're aiming for in this game:
 
 - Fast action: the player moves around a lot.
-- Good sound effects: to immerse the player in the game and contribute to the overall game vibe. 
+- Good sound effects: to immerse the player in the game and contribute to the overall game vibe.
 - Lots of shooting opportunities.
 - Increasing challenge: the game gets harder and faster as the player gets better.
 
@@ -30,19 +30,19 @@ After the repl has booted up, you should see a `main.js` file under the "Code" s
 
 ## Getting Started with Kaboom.js
 
-[Kaboom.js](https://kaboomjs.com) is a JavaScript library that contains a lot of useful features for making simple browser games. It has functionality to draw shapes and sprites (the images of characters and game elements) to the screen, get user input, play sounds, and more. We'll use some of these features in our game to explore how Kaboom works. 
+[Kaboom.js](https://kaboomjs.com) is a JavaScript library that contains a lot of useful features for making simple browser games. It has functionality to draw shapes and sprites (the images of characters and game elements) to the screen, get user input, play sounds, and more. We'll use some of these features in our game to explore how Kaboom works.
 
-The Replit Kaboom interface is specialised for game-making. Besides the Space Invader icon, you'll notice a few special folders in the file tray, like "Code", "Sprites", and "Sounds". These special folders take care of loading up assets, and all the necessary code to start scenes and direct the game. You can read up more about this interface [here](https://docs.replit.com/tutorials/kaboom). 
+The Replit Kaboom interface is specialised for game-making. Besides the Space Invader icon, you'll notice a few special folders in the file tray, like "Code", "Sprites", and "Sounds". These special folders take care of loading up assets, and all the necessary code to start scenes and direct the game. You can read up more about this interface [here](https://docs.replit.com/tutorials/kaboom).
 
-If you haven't already, download this [zip file](/tutorial-files/space-shooter-kaboom/space-shooter-resources.zip) which contains all the sprites and sounds for the game. Extract the file on your computer, then add the sprites to the "Sprites" section in the Replit editor, and the sounds to the "Sounds" section. 
+If you haven't already, download this [zip file](/tutorial-files/space-shooter-kaboom/space-shooter-resources.zip) which contains all the sprites and sounds for the game. Extract the file on your computer, then add the sprites to the "Sprites" section in the Replit editor, and the sounds to the "Sounds" section.
 
 <img src="/images/tutorials/24-space-shooter-kaboom/upload-sprites.gif"
     alt="Uploading assets"
     style="width: 500px !important;"/>
 
-Kaboom makes good use of JavaScript's support for [callbacks](https://developer.mozilla.org/en-US/docs/Glossary/Callback_function): instead of writing loops to read keyboard input and check if game objects have collided, Kaboom uses an event model that tells us when these events have happened. We can then write [callback functions](https://developer.mozilla.org/en-US/docs/Glossary/Callback_function) to act on these events. 
+Kaboom makes good use of JavaScript's support for [callbacks](https://developer.mozilla.org/en-US/docs/Glossary/Callback_function): instead of writing loops to read keyboard input and check if game objects have collided, Kaboom uses an event model that tells us when these events have happened. We can then write [callback functions](https://developer.mozilla.org/en-US/docs/Glossary/Callback_function) to act on these events.
 
-A Kaboom game is made up of "scenes", which are like levels, or different parts and stages of a game. Scenes have multiple "layers", allowing us to have game backgrounds, main game objects (like the player, bullets, enemies, etc), and UI elements (like the current score, health, etc). 
+A Kaboom game is made up of "scenes", which are like levels, or different parts and stages of a game. Scenes have multiple "layers", allowing us to have game backgrounds, main game objects (like the player, bullets, enemies, etc), and UI elements (like the current score, health, etc).
 
 
 ## Setting up Kaboom
@@ -90,7 +90,7 @@ Kaboom ["scenes"](https://kaboomjs.com/#scene) allow us to group logic and level
 
 ```javascript
 scene("main", () => {
-  
+
   layers([
     "bg",
     "obj",
@@ -102,7 +102,7 @@ scene("main", () => {
     sprite("stars"),
     layer("bg")
   ]);
-  
+
 });
 
 go("main");
@@ -117,7 +117,7 @@ Finally, we use the [`go`](https://kaboomjs.com/#go) function to go to the main 
 
 Let's get a scene layout, or _map_, drawn on the screen. This will define the ground and platforms in the game.
 
-Kaboom has built-in support for defining game maps using text and the function [`addLevel`](https://kaboomjs.com/doc#addLevel). This takes away a lot of the hassle normally involved in loading and rendering maps. 
+Kaboom has built-in support for defining game maps using text and the function [`addLevel`](https://kaboomjs.com/doc#addLevel). This takes away a lot of the hassle normally involved in loading and rendering maps.
 
 
 Add the code below to the `main.js` file, within the main scene, to create the game map:
@@ -185,13 +185,13 @@ const map = addLevel([
 
 ```
 
-First, we add some game parameters, which we'll use when we define the size of the map, and the default block size for map elements. 
+First, we add some game parameters, which we'll use when we define the size of the map, and the default block size for map elements.
 
 Next, we create the game map. The map, or level design, is expressed in an array of strings. Each row in the array represents one row on the screen, so we can design visually in text what the map should look like. The width and height parameters specify the size of each of the elements in the map. The `pos` parameter specifies where on the screen the map should be placed – we chose `0,0`, which is the top left of the screen, as the starting point for the map.
 
-Kaboom allows us to specify what to draw for each symbol in the text map. You can make maps out of different elements, e.g. a symbol for a wall, a symbol for ground, a symbol for a hump, and so on. To tell Kaboom what to draw for the symbol, we add the symbol as a key, for example `=`, and then specify parameters for it. 
+Kaboom allows us to specify what to draw for each symbol in the text map. You can make maps out of different elements, e.g. a symbol for a wall, a symbol for ground, a symbol for a hump, and so on. To tell Kaboom what to draw for the symbol, we add the symbol as a key, for example `=`, and then specify parameters for it.
 
-In this code, we have 3 different type of fixed map elements: `=` representing the ground, `p` representing platforms, and `-` representing the invisible boundaries of the screen. Each of the  map elements has a tag (`ground`, `platform`, `boundary`) which is the string name grouping the individual pieces together. This allows us to refer to them collectively later.  
+In this code, we have 3 different type of fixed map elements: `=` representing the ground, `p` representing platforms, and `-` representing the invisible boundaries of the screen. Each of the  map elements has a tag (`ground`, `platform`, `boundary`) which is the string name grouping the individual pieces together. This allows us to refer to them collectively later.
 
 If we run the code, we should see the game map, like this:
 
@@ -219,77 +219,77 @@ const player = add([
 
 ```
 
-The [`add`](https://kaboomjs.com/doc#add) function constructs a game object using different components, e.g. `pos`, `body`, `scale`, etc. Each of these components gives the object different features. 
+The [`add`](https://kaboomjs.com/doc#add) function constructs a game object using different components, e.g. `pos`, `body`, `scale`, etc. Each of these components gives the object different features.
 
-Notably, the [`body`](https://kaboomjs.com/doc#body) component makes the object react to gravity: the spaceship falls if it's not on the ground or a platform. The [`rotate`](https://kaboomjs.com/doc#rotate) component allows us to tilt the spaceship in the direction the player wants to go, providing good visual feedback. By default, all operations are calculated around the top left corner of game objects. To make the tilt work correctly, we add the [`origin`](https://kaboomjs.com/doc#origin) component and set it to `center`, so that the tilt adjusts the angle from the center of the object. 
+Notably, the [`body`](https://kaboomjs.com/doc#body) component makes the object react to gravity: the spaceship falls if it's not on the ground or a platform. The [`rotate`](https://kaboomjs.com/doc#rotate) component allows us to tilt the spaceship in the direction the player wants to go, providing good visual feedback. By default, all operations are calculated around the top left corner of game objects. To make the tilt work correctly, we add the [`origin`](https://kaboomjs.com/doc#origin) component and set it to `center`, so that the tilt adjusts the angle from the center of the object.
 
-Kaboom also allows us to attach custom data to a game object. We've added `score` to hold the player's latest score, and `shield` to hold the percentage of the ship's protection shield still available. We can adjust these as the player picks up items or crashes into aliens. 
+Kaboom also allows us to attach custom data to a game object. We've added `score` to hold the player's latest score, and `shield` to hold the percentage of the ship's protection shield still available. We can adjust these as the player picks up items or crashes into aliens.
 
-When we created the `map` earlier, we added the [`solid`](https://kaboomjs.com/doc#solid) component to map objects. This component marks objects as solid, meaning other objects can't move past them. 
+When we created the `map` earlier, we added the [`solid`](https://kaboomjs.com/doc#solid) component to map objects. This component marks objects as solid, meaning other objects can't move past them.
 
 
 ## Moving the Spaceship
 
-We'll allow a few different moves for the spaceship: change direction left or right and fly up. We also need to keep track of which way the spaceship is facing, so that we'll know which side to shoot lasers from later. 
+We'll allow a few different moves for the spaceship: change direction left or right and fly up. We also need to keep track of which way the spaceship is facing, so that we'll know which side to shoot lasers from later.
 
 To handle the changing and tracking of direction, add the following code:
 
 ```javascript
 const directions = {
-  LEFT: "left", 
+  LEFT: "left",
   RIGHT: "right"
 }
 
-let current_direction = directions.RIGHT; 
+let current_direction = directions.RIGHT;
 
 keyDown("left", () => {
     player.flipX(-1);
-    player.angle = -0.2; 
-    current_direction = directions.LEFT; 
+    player.angle = -0.2;
+    current_direction = directions.LEFT;
     player.move(-100,0);
 });
 
 keyDown("right", () => {
     player.flipX(1);
-    player.angle = -0.2; 
-    current_direction = directions.RIGHT; 
-    player.move(100,0);  
+    player.angle = -0.2;
+    current_direction = directions.RIGHT;
+    player.move(100,0);
 });
 
 
 keyRelease("left", ()=>{
-    player.angle = 0; 
-}); 
+    player.angle = 0;
+});
 
 keyRelease("right", ()=>{
-    player.angle = 0; 
-}); 
+    player.angle = 0;
+});
 
 ```
 
 First, we create a constant object defining the directions our game allows. Then we create a variable to track the `current_direction` the spaceship is facing.
 
-Then we add the key-handling code. The key names `left` and `right` refer to the left and right arrow keys on the keyboard. Kaboom provides the [`keyDown`](https://kaboomjs.com/doc#keyDown) event, which lets us know if a certain key is being pressed. We create `keyDown` event handlers for each of the arrow keys. As long as the given key is held down, `keyDown` calls the event handler repeatedly. 
+Then we add the key-handling code. The key names `left` and `right` refer to the left and right arrow keys on the keyboard. Kaboom provides the [`keyDown`](https://kaboomjs.com/doc#keyDown) event, which lets us know if a certain key is being pressed. We create `keyDown` event handlers for each of the arrow keys. As long as the given key is held down, `keyDown` calls the event handler repeatedly.
 
-The code inside each `keyDown` event does the following: 
-- The `flipX` function mirrors the player's spaceship image so that it looks different depending on the direction it is facing. We use `-1` to flip it to appear facing the left, `1` the right. 
-- The function `player.angle` slightly tilts the spaceship while the key is being held down. This is so the spaceship looks like it is about to move in the given direction. 
-- The `current_direction` tracking variable is updated. We'll use this variable when we add shooting. 
-- The `move` function moves the spaceship in the given direction. 
+The code inside each `keyDown` event does the following:
+- The `flipX` function mirrors the player's spaceship image so that it looks different depending on the direction it is facing. We use `-1` to flip it to appear facing the left, `1` the right.
+- The function `player.angle` slightly tilts the spaceship while the key is being held down. This is so the spaceship looks like it is about to move in the given direction.
+- The `current_direction` tracking variable is updated. We'll use this variable when we add shooting.
+- The `move` function moves the spaceship in the given direction.
 
-We also have `keyRelease` event handlers for the left and right keys. These reset the spaceship's tilt angle to 0 (i.e. straight up) when the ship is no longer moving in that direction. 
+We also have `keyRelease` event handlers for the left and right keys. These reset the spaceship's tilt angle to 0 (i.e. straight up) when the ship is no longer moving in that direction.
 
 Now we want to have the spaceship fly up when we press the `up arrow` key. To do this, we'll take advantage of Kaboom's [`jump`](https://kaboomjs.com/doc#body) attribute (which is part of the [`body`](https://kaboomjs.com/doc#body) component) and repurpose it for flying up. Add the following code to the main scene:
 
 ```javascript
 keyDown("up", () => {
-      player.jump(100); 
+      player.jump(100);
 });
 ```
 
 ## Adding Laser Guns
 
-Because the game takes place in outer space, the weapon of choice is a laser gun. We'll need to add functions to create the bullet when the player fires, and to control the direction of the bullets. We'll also need to add another key handler to check when the player presses a key to "fire", which is the space key in this game. 
+Because the game takes place in outer space, the weapon of choice is a laser gun. We'll need to add functions to create the bullet when the player fires, and to control the direction of the bullets. We'll also need to add another key handler to check when the player presses a key to "fire", which is the space key in this game.
 
 ```javascript
 
@@ -301,9 +301,9 @@ keyPress("space", () => {
 
 function spawnBullet(bulletpos) {
     if (current_direction == directions.LEFT){
-        bulletpos = bulletpos.sub(10,0); 
+        bulletpos = bulletpos.sub(10,0);
     } else if (current_direction == directions.RIGHT){
-        bulletpos = bulletpos.add(10,0); 
+        bulletpos = bulletpos.add(10,0);
     }
 	add([
 		rect(6, 2),
@@ -313,7 +313,7 @@ function spawnBullet(bulletpos) {
         area(),
 		"bullet",
         {
-            bulletSpeed : current_direction == directions.LEFT?-1*BULLET_SPEED: BULLET_SPEED 
+            bulletSpeed : current_direction == directions.LEFT?-1*BULLET_SPEED: BULLET_SPEED
         }
 	]);
 
@@ -324,33 +324,33 @@ function spawnBullet(bulletpos) {
 };
 ```
 
-First, we add a constant `BULLET_SPEED` to define the speed at which the laser "bullets" fly across the screen. Then we use the [`keyPress`](https://kaboomjs.com/doc#keyPress) event to trigger the shooting. Notice `keyPress` only calls the event handler once as the key is pressed, unlike the `keyDown` event we used for moving. This is because it's more fun if the player needs to bash the "fire" button as fast as possible to take down an enemy, rather than just having automatic weapons. 
+First, we add a constant `BULLET_SPEED` to define the speed at which the laser "bullets" fly across the screen. Then we use the [`keyPress`](https://kaboomjs.com/doc#keyPress) event to trigger the shooting. Notice `keyPress` only calls the event handler once as the key is pressed, unlike the `keyDown` event we used for moving. This is because it's more fun if the player needs to bash the "fire" button as fast as possible to take down an enemy, rather than just having automatic weapons.
 
 The `keyPress` handler calls the `spawnBullet` function with the player's current position. This function handles creating a new laser shot in the correct direction. The first few lines of the method adjust the bullet's starting position a little to the left or right of the spaceship's position. This is because the position of the spaceship that gets passed to the function is the center of the spaceship (remember the `origin` component we added to it earlier). We adjust it a little so that the bullet looks like it is coming from the edge of the spaceship.
 
-Then we add a new bullet object to the game using the [`add`](https://kaboomjs.com/doc#add) function. We don't use a sprite for the bullet, but draw a [`rect`](https://kaboomjs.com/doc#rect), or rectangle, with our given color. We tag it `bullet` so we can refer to it later when detecting if it hit something. We also give it a custom property, `bulletSpeed`, which is the distance and direction we want the bullet to move on each frame. 
+Then we add a new bullet object to the game using the [`add`](https://kaboomjs.com/doc#add) function. We don't use a sprite for the bullet, but draw a [`rect`](https://kaboomjs.com/doc#rect), or rectangle, with our given color. We tag it `bullet` so we can refer to it later when detecting if it hit something. We also give it a custom property, `bulletSpeed`, which is the distance and direction we want the bullet to move on each frame.
 
-Finally, we add sound effects when the player shoots. The [`play`](https://kaboomjs.com/doc#play) function plays our "shoot.wav" file. We adjust the volume down a bit, so it fits in better with the overall sound mix. We use the `detune` parameter along with a random number generator, [`rand`]('https://kaboomjs.com/doc#rand'), to change the pitch of the sound each time it's played. This is so the sound doesn't become too repetitive and also because it sounds weird and "spacey". 
+Finally, we add sound effects when the player shoots. The [`play`](https://kaboomjs.com/doc#play) function plays our "shoot.wav" file. We adjust the volume down a bit, so it fits in better with the overall sound mix. We use the `detune` parameter along with a random number generator, [`rand`]('https://kaboomjs.com/doc#rand'), to change the pitch of the sound each time it's played. This is so the sound doesn't become too repetitive and also because it sounds weird and "spacey".
 
-Now that we've set up the bullet, we need to make it move on each frame. To do this we can use the [`action`](https://kaboomjs.com/doc#action) event, using the `bullet` tag to identify the objects we want to update:
+Now that we've set up the bullet, we need to make it move on each frame. To do this we can use the [`onUpdate`](https://kaboomjs.com/doc#onUpdate) event, using the `bullet` tag to identify the objects we want to update:
 
 ```javascript
-action("bullet", (b) => {
+onUpdate("bullet", (b) => {
 	b.move(b.bulletSpeed,0);
 	if ((b.pos.x < 0) ||(b.pos.x > MAP_WIDTH)) {
-		destroy(b); 
+		destroy(b);
 	}
 });
 ```
 
-With each frame, the action event updates the objects with the matching tag, in this case `bullet`. We call [`move`](https://kaboomjs.com/doc#pos) on the bullet, using the custom value for `bulletSpeed` that we assigned to it on creation. We also check to see if the bullet has gone off the screen, and if it has, we [`destroy`](https://kaboomjs.com/doc#destroy) it. 
+With each frame, the action event updates the objects with the matching tag, in this case `bullet`. We call [`move`](https://kaboomjs.com/doc#pos) on the bullet, using the custom value for `bulletSpeed` that we assigned to it on creation. We also check to see if the bullet has gone off the screen, and if it has, we [`destroy`](https://kaboomjs.com/doc#destroy) it.
 
-We also need to destroy the bullet if it hits a platform. We can do this using the Kaboom [`collides`](https://kaboomjs.com/doc#collides) event. Add the following code: 
+We also need to destroy the bullet if it hits a platform. We can do this using the Kaboom [`onCollide`](https://kaboomjs.com/doc#onCollide) event. Add the following code:
 
 ```javascript
-collides("bullet","platform", (bullet, platform) =>{
-    destroy(bullet); 
-}); 
+onCollide("bullet","platform", (bullet, platform) =>{
+    destroy(bullet);
+});
 ```
 
 Run the code now, and you should be able to shoot.
@@ -359,20 +359,20 @@ Run the code now, and you should be able to shoot.
 
 ## Adding Alien Space Bugs
 
-Now that we have a spacecraft, and it can shoot, we need something to shoot at. Let's add some hostile exploding alien space bugs. We'll want to have them coming in a relatively constant stream to keep the game challenging. We also want them coming in from different sides and angles to keep the player on their toes. We'll add a new function to control the creation of alien space bugs: 
+Now that we have a spacecraft, and it can shoot, we need something to shoot at. Let's add some hostile exploding alien space bugs. We'll want to have them coming in a relatively constant stream to keep the game challenging. We also want them coming in from different sides and angles to keep the player on their toes. We'll add a new function to control the creation of alien space bugs:
 
 ```javascript
 
-const ALIEN__BASE_SPEED = 100; 
-const ALIEN_SPEED_INC = 20; 
+const ALIEN__BASE_SPEED = 100;
+const ALIEN_SPEED_INC = 20;
 
 function spawnAlien() {
-    let alienDirection = choose([directions.LEFT, directions.RIGHT]); 
-    let xpos = (alienDirection == directions.LEFT ? 0:MAP_WIDTH); 
+    let alienDirection = choose([directions.LEFT, directions.RIGHT]);
+    let xpos = (alienDirection == directions.LEFT ? 0:MAP_WIDTH);
 
-    const points_speed_up = Math.floor(player.score / 1000); 
-    const alien_speed = ALIEN__BASE_SPEED + (points_speed_up * ALIEN_SPEED_INC); 
-    const new_alien_interval = 0.8 - (points_speed_up/20); 
+    const points_speed_up = Math.floor(player.score / 1000);
+    const alien_speed = ALIEN__BASE_SPEED + (points_speed_up * ALIEN_SPEED_INC);
+    const new_alien_interval = 0.8 - (points_speed_up/20);
 
 	add([
 		sprite("alien"),
@@ -388,38 +388,38 @@ function spawnAlien() {
 	wait(new_alien_interval, spawnAlien);
 }
 
-spawnAlien(); 
+spawnAlien();
 ```
 
 We create 2 parameters for the alien's speed: a base rate and an incremental rate. Each time the player gains another 1000 points, we'll add to the incremental rate.
 
-**Tip:** You can put these parameters and all the others we have defined at the top of the file, so that they are easy to find and adjust if you want to tweak the game parameters later. 
+**Tip:** You can put these parameters and all the others we have defined at the top of the file, so that they are easy to find and adjust if you want to tweak the game parameters later.
 
 Then we define the `spawnAlien` function. To randomly choose the side of the screen the alien will fly in from, we use the Kaboom [`choose`](https://kaboomjs.com/doc#choose) function, which picks an element at random from an array. From the chosen direction, we can determine the alien's starting position on the `x axis` (horizontal plane).
 
-Then we go into the calculation to figure out the speed that the alien should move at. First, we check if we need to increase the alien's speed based on the player's score. We divide the player's score by 1000 (since the aliens' speed increases with every 1000 points the player earns). We get rid of decimals by using the [`Math.floor`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/floor) function, which is built into JavaScript. The result is our `points_speed_up` value. 
+Then we go into the calculation to figure out the speed that the alien should move at. First, we check if we need to increase the alien's speed based on the player's score. We divide the player's score by 1000 (since the aliens' speed increases with every 1000 points the player earns). We get rid of decimals by using the [`Math.floor`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/floor) function, which is built into JavaScript. The result is our `points_speed_up` value.
 
 Next we take the `ALIEN_BASE_SPEED` and add the incremental rate multiplied by our `points_speed_up` value.
 
-We also calculate a new rate at which aliens are spawned, making the aliens not only faster at moving, but also faster at respawning. 
+We also calculate a new rate at which aliens are spawned, making the aliens not only faster at moving, but also faster at respawning.
 
 Now that we've calculated our basic parameters, we create a new alien using the [`add`](https://kaboomjs.com/doc#add) function again:
-- `sprite('alien')` creates the alien with the image `alien`. 
-- `pos(xpos, rand(0, MAP_HEIGHT-20))` sets the starting position of the alien. We calculated the `x pos` from the randomly chosen direction. We also add a random `y` (vertical) position for the alien, between the top (position `0`) of the map, and the bottom (`MAP_HEIGHT`) of the map (screen co-ordinates start from the top left of the screen). We remove `20` pixels from the bottom bounds, to account for the ground. 
-- We add the `"alien"` tag to the object, so we can identify and call it in other parts of the code. 
-- We also add a custom object with the speed of this particular alien, broken into it's speed along the `x` and `y` axis. For the speed along the x-axis `speedX`, we add a random component so that not all aliens move at exactly the same speed. Then we multiply the speed by -1 or 1 depending on whether the alien is meant to be moving left or right across the screen. 
+- `sprite('alien')` creates the alien with the image `alien`.
+- `pos(xpos, rand(0, MAP_HEIGHT-20))` sets the starting position of the alien. We calculated the `x pos` from the randomly chosen direction. We also add a random `y` (vertical) position for the alien, between the top (position `0`) of the map, and the bottom (`MAP_HEIGHT`) of the map (screen co-ordinates start from the top left of the screen). We remove `20` pixels from the bottom bounds, to account for the ground.
+- We add the `"alien"` tag to the object, so we can identify and call it in other parts of the code.
+- We also add a custom object with the speed of this particular alien, broken into it's speed along the `x` and `y` axis. For the speed along the x-axis `speedX`, we add a random component so that not all aliens move at exactly the same speed. Then we multiply the speed by -1 or 1 depending on whether the alien is meant to be moving left or right across the screen.
 
-Finally, we use Kaboom's [`wait`](https://kaboomjs.com/doc#wait) function to wait a short amount of time before calling `spawnAlien` again to create a new alien. We also have a call to `spawnAlien` to get it started when the game starts. 
+Finally, we use Kaboom's [`wait`](https://kaboomjs.com/doc#wait) function to wait a short amount of time before calling `spawnAlien` again to create a new alien. We also have a call to `spawnAlien` to get it started when the game starts.
 
 
 ## Moving the Aliens
 
-To move the aliens, we'll create a handler to attach to the `action` event, which fires for each alien object on every frame, like we did for the bullets: 
+To move the aliens, we'll create a handler to attach to the `onUpdate` event, which fires for each alien object on every frame, like we did for the bullets:
 
 ```javascript
-action("alien", (alien) => {
+onUpdate("alien", (alien) => {
 	alien.move(alien.speedX, alien.speedY);
-	
+
 	if ((alien.pos.y - alien.height > MAP_HEIGHT) || (alien.pos.y < 0)) {
 		destroy(alien);
 	}
@@ -429,9 +429,9 @@ action("alien", (alien) => {
 });
 ```
 
-First, the function moves the alien by the amount we calculated earlier and saved to the alien's custom data. 
+First, the function moves the alien by the amount we calculated earlier and saved to the alien's custom data.
 
-Then the function checks to see if the alien has moved out of bounds of the map area. If it has, we destroy it, as it is no longer visible. Having too many active objects can decrease performance, so this step is important. 
+Then the function checks to see if the alien has moved out of bounds of the map area. If it has, we destroy it, as it is no longer visible. Having too many active objects can decrease performance, so this step is important.
 
 Run the code now, you should see moving aliens.
 
@@ -439,23 +439,23 @@ Run the code now, you should see moving aliens.
 
 ## Shooting the Aliens
 
-Now that we have moving aliens, a moving spaceship, and laser bullets, let's add the code to deal with a laser bullet hitting an alien. Of course, we want this to have a cool explosion and sound effect to give good feedback to the player. 
+Now that we have moving aliens, a moving spaceship, and laser bullets, let's add the code to deal with a laser bullet hitting an alien. Of course, we want this to have a cool explosion and sound effect to give good feedback to the player.
 
 
 ```javascript
-collides("alien","bullet", (alien, bullet) =>{
+onCollide("alien","bullet", (alien, bullet) =>{
     makeExplosion(alien.pos, 5, 5, 5);
-    destroy(alien); 
-    destroy(bullet); 
+    destroy(alien);
+    destroy(bullet);
     play("explosion", {
 		volume: 0.2,
 		detune: rand(0, 1200),
-	}); 
-}); 
+	});
+});
 
 ```
 
-This is similar to the code used before to check if a bullet has hit a platform. We [`destroy`](https://kaboomjs.com/doc#destroy) both the bullet and alien to remove them from the scene. Then we use the [`play`](https://kaboomjs.com/doc#playhttps://kaboomjs.com/doc#play) function to play the explosion sound effect. We set the volume so it fits in the mix, and we also put a random detune (pitch adjust) on the sound, to vary it and make it more interesting when a lot of aliens are being shot at. 
+This is similar to the code used before to check if a bullet has hit a platform. We [`destroy`](https://kaboomjs.com/doc#destroy) both the bullet and alien to remove them from the scene. Then we use the [`play`](https://kaboomjs.com/doc#playhttps://kaboomjs.com/doc#play) function to play the explosion sound effect. We set the volume so it fits in the mix, and we also put a random detune (pitch adjust) on the sound, to vary it and make it more interesting when a lot of aliens are being shot at.
 
 We also call out to a function to create an explosion around the area where the alien bug used to be. This code is from the ["shooter" example on the Kaboom examples page](https://kaboomjs.com/demo#shooter) (which is a great game). It makes a series of bright white flashes around the explosion site, giving a cool cartoon or comic-book-like feel to the explosions. Add this code:
 
@@ -507,52 +507,52 @@ The `makeExplosion` function has four _arguments_ (inputs to the function). Thes
 - `rad`, the radius or distance from `p` to make the flashes in
 - `size`, the size of each of the flashes
 
-The function creates a [`for loop`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for) to loop for `n` times (the number of main flashes we want to make). It uses the Kaboom [`wait`](https://kaboomjs.com/doc#wait) function to leave a little bit of time (0.1) seconds between each main flash. 
+The function creates a [`for loop`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for) to loop for `n` times (the number of main flashes we want to make). It uses the Kaboom [`wait`](https://kaboomjs.com/doc#wait) function to leave a little bit of time (0.1) seconds between each main flash.
 
-Another `for loop` loops twice to create 2 sub flashes, using the Kaboom [`add`](https://kaboomjs.com/doc#add) function to add a [`rectangle`](https://kaboomjs.com/doc#rect) shape for each flash, and setting the color to bright white (color components in Kaboom go from 0-1). This rectangle starts out at 1 pixel in each dimension. Then the [`scale`](https://kaboomjs.com/doc#scale) component is added to increase the size of the flash to the `size` passed in to the function - we'll use this later when we "grow" the explosion. The [`origin`](https://kaboomjs.com/doc#origin) component is used to set the origin of the rectangle to it's center - this will be used when we "grow" the flash to give the impression that it is starting from a small point and exploding. We set the origin as the center so that scale is calculated from this position, giving it a more natural feel. 
+Another `for loop` loops twice to create 2 sub flashes, using the Kaboom [`add`](https://kaboomjs.com/doc#add) function to add a [`rectangle`](https://kaboomjs.com/doc#rect) shape for each flash, and setting the color to bright white (color components in Kaboom go from 0-1). This rectangle starts out at 1 pixel in each dimension. Then the [`scale`](https://kaboomjs.com/doc#scale) component is added to increase the size of the flash to the `size` passed in to the function - we'll use this later when we "grow" the explosion. The [`origin`](https://kaboomjs.com/doc#origin) component is used to set the origin of the rectangle to it's center - this will be used when we "grow" the flash to give the impression that it is starting from a small point and exploding. We set the origin as the center so that scale is calculated from this position, giving it a more natural feel.
 
-To make the flashes appear around the position `p` that we specified, the [`pos`](https://kaboomjs.com/doc#pos) component is adjusted by a random amount, ranging from `-rad` to `rad`, the radius we specified (in other words, the blast area). 
+To make the flashes appear around the position `p` that we specified, the [`pos`](https://kaboomjs.com/doc#pos) component is adjusted by a random amount, ranging from `-rad` to `rad`, the radius we specified (in other words, the blast area).
 
-Then there are references to two custom components - `lifespan` and `grow`. Kaboom allows us to define our own components to give objects any behaviour or attributes we want. All we need to do is create a function that returns an object with a method called `update`, which is then called for each frame of the object the component is added to. 
+Then there are references to two custom components - `lifespan` and `grow`. Kaboom allows us to define our own components to give objects any behaviour or attributes we want. All we need to do is create a function that returns an object with a method called `update`, which is then called for each frame of the object the component is added to.
 
-Let's first look at the custom component `grow`. This is used to create the effect of the flash expanding outwards, like a firework explosion starting at a small point and getting larger until it disappears. In `grow`'s `update` function, the object is scaled up (available because we used the [`scale`](https://kaboomjs.com/doc#scale) component on the object) on each frame. This is calculated from the `rate` passed in - which is the size the object should grow per second, multiplied by the time difference from the last frame, using the Kaboom [`dt`](https://kaboomjs.com/doc#dt) function, which provides that time difference in seconds for us. The explosion flash will keep on growing in each frame, so we need a way to end the explosion before it covers the entire screen. 
+Let's first look at the custom component `grow`. This is used to create the effect of the flash expanding outwards, like a firework explosion starting at a small point and getting larger until it disappears. In `grow`'s `update` function, the object is scaled up (available because we used the [`scale`](https://kaboomjs.com/doc#scale) component on the object) on each frame. This is calculated from the `rate` passed in - which is the size the object should grow per second, multiplied by the time difference from the last frame, using the Kaboom [`dt`](https://kaboomjs.com/doc#dt) function, which provides that time difference in seconds for us. The explosion flash will keep on growing in each frame, so we need a way to end the explosion before it covers the entire screen.
 
-This brings us to the `lifespan` component. This is implemented to automatically [`destroy`](https://kaboomjs.com/doc#destroy) the object after a short time, to solve the ever-growing explosion problem. It works by having a `timer` variable, which is updated each frame with the difference in time from the last frame, using the Kaboom [`dt`](https://kaboomjs.com/doc#dt) function again. When the `timer` count is more than the `time` parameter passed into the component, the object is automatically [`destroyed`](https://kaboomjs.com/doc#destroy). This creates the impression of a quick explosion blast. 
+This brings us to the `lifespan` component. This is implemented to automatically [`destroy`](https://kaboomjs.com/doc#destroy) the object after a short time, to solve the ever-growing explosion problem. It works by having a `timer` variable, which is updated each frame with the difference in time from the last frame, using the Kaboom [`dt`](https://kaboomjs.com/doc#dt) function again. When the `timer` count is more than the `time` parameter passed into the component, the object is automatically [`destroyed`](https://kaboomjs.com/doc#destroy). This creates the impression of a quick explosion blast.
 
 ![Shooting Aliens](/images/tutorials/24-space-shooter-kaboom/shooting-aliens.gif)
 
 ## Exploding the Alien Bugs on Contact
 
-When the alien bugs hit something solid, they should explode. To do this, we'll add the following code: 
+When the alien bugs hit something solid, they should explode. To do this, we'll add the following code:
 
 ```javascript
-collides("alien","platform", (alien, platform) =>{
+onCollide("alien","platform", (alien, platform) =>{
     makeExplosion(alien.pos, 5, 3, 3);
-    destroy(alien); 
+    destroy(alien);
     play("explosion", {
 		volume: 0.1,
 		detune: rand(-1200, 1200),
 	});
-}); 
+});
 
-collides("alien","ground", (alien, ground) =>{
+onCollide("alien","ground", (alien, ground) =>{
     makeExplosion(alien.pos, 5, 3, 3);
-    destroy(alien); 
+    destroy(alien);
     play("explosion", {
 		volume: 0.1,
 		detune: rand(-1200, 1200),
 	});
-}); 
+});
 ```
 
-Here we have 2 collision handlers: one for aliens hitting a platform, and one for aliens hitting the ground. They both do the same thing. First, since we have a great explosion creating function, we use it gratuitously. Then we [`destroy`](https://kaboomjs.com/doc#destroy) the alien object to remove it from the scene. Finally, we play an explosion sound effect at a lower volume, as this explosion is not caused by the player and doesn't directly affect them. We also add the usual random [`detune`](https://kaboomjs.com/doc#play) function to modify the sound each time and keep it interesting. 
+Here we have 2 collision handlers: one for aliens hitting a platform, and one for aliens hitting the ground. They both do the same thing. First, since we have a great explosion creating function, we use it gratuitously. Then we [`destroy`](https://kaboomjs.com/doc#destroy) the alien object to remove it from the scene. Finally, we play an explosion sound effect at a lower volume, as this explosion is not caused by the player and doesn't directly affect them. We also add the usual random [`detune`](https://kaboomjs.com/doc#play) function to modify the sound each time and keep it interesting.
 
 
 ## Adding Score and Shield UI
 
-Let's add the UI to show the ship's shield health and the player's overall score. 
+Let's add the UI to show the ship's shield health and the player's overall score.
 
-First, add text for the player's score: 
+First, add text for the player's score:
 
 ```javascript
 add([
@@ -570,25 +570,25 @@ const scoreText = add ([
 ]);
 ```
 
-Here we add two new objects, rendered with the [`text`](https://kaboomjs.com/doc#text) component. The first is just the static label for the score. The second is the text placeholder for the actual score. Note that the [`layer`](https://kaboomjs.com/doc#layer) component is used in both cases to place the text on the UI layer we created at the start of the tutorial. We haven't had to specify the layer for all our other game objects, because we set the `obj` layer as the default to use when we defined the layers. 
+Here we add two new objects, rendered with the [`text`](https://kaboomjs.com/doc#text) component. The first is just the static label for the score. The second is the text placeholder for the actual score. Note that the [`layer`](https://kaboomjs.com/doc#layer) component is used in both cases to place the text on the UI layer we created at the start of the tutorial. We haven't had to specify the layer for all our other game objects, because we set the `obj` layer as the default to use when we defined the layers.
 
-Now that we have the UI components for showing the score, we need a function to update the score when it changes, and reflect it on the UI. 
+Now that we have the UI components for showing the score, we need a function to update the score when it changes, and reflect it on the UI.
 
 ```javascript
 function updateScore(points){
-    player.score += points; 
-    scoreText.text = player.score.toString().padStart(6,0); 
+    player.score += points;
+    scoreText.text = player.score.toString().padStart(6,0);
     play("score", {
 		volume: 0.5,
 		detune: rand(-1200, 1200),
 	});
 }
 ```
-This `updateScore` function takes as its argument the number of points to add to the score and adds them to the player's current score - remember we added `score` as a custom property when we created the player (spaceship) object. 
+This `updateScore` function takes as its argument the number of points to add to the score and adds them to the player's current score - remember we added `score` as a custom property when we created the player (spaceship) object.
 
 Next we update the `scoreText` UI element we created previously. The player's score is converted to a string using JavaScript's [`toString`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/toString) method, which is part of every object in JavaScript. It is also modified with [`padStart`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/padStart), which makes sure the resulting score string is exactly `6` digits long, using 0s to put in front of the string (`start`) if the number is smaller than 6 digits long. This makes nice placeholders for the score, and gives a cue to the users as to the maximum score they could reach. Finally, we play a little sound to indicate that points have been earned. As before, we vary the pitch each time using [`detune`](https://kaboomjs.com/doc#play) to keep the sound fresh.
 
-The next UI element to add is the ship's shield health. This would be great as a kind of health-bar-style display, that starts out green and turns red when the shield is low. The game should end when the shield is fully depleted, as the spaceship is then totally destroyed. 
+The next UI element to add is the ship's shield health. This would be great as a kind of health-bar-style display, that starts out green and turns red when the shield is low. The game should end when the shield is fully depleted, as the spaceship is then totally destroyed.
 
 ```javascript
 add([
@@ -625,41 +625,41 @@ const shieldBar = add ([
 First, we add a text label so that players know what the bar represents. To create the shield bar UI, we use 3 elements :
 * A border, or `shieldHolder`, to outline the bar.
 * A black inner block to make the holder look like a thin line, `shieldHolderInside`.
-* The `shieldBar` itself, which will get shorter as the shield is damaged. 
+* The `shieldBar` itself, which will get shorter as the shield is damaged.
 
 
 Now we need a function to call when we want to update the shield's health:
 
 ```javascript
 function updatePlayerShield(shieldPoints){
-    player.shield += shieldPoints; 
-    player.shield = Math.max(player.shield, 0); 
-    player.shield = Math.min(player.shield, 100); 
+    player.shield += shieldPoints;
+    player.shield = Math.max(player.shield, 0);
+    player.shield = Math.min(player.shield, 100);
 
     shieldBar.width = 50 * (player.shield / 100);
 
-    if (player.shield < 20) shieldBar.color = rgb(255,0,0); 
-    else if (player.shield < 50) shieldBar.color = rgb(255,127,0); 
-    else shieldBar.color = rgb(0,255,0); 
+    if (player.shield < 20) shieldBar.color = rgb(255,0,0);
+    else if (player.shield < 50) shieldBar.color = rgb(255,127,0);
+    else shieldBar.color = rgb(0,255,0);
 
-    if (player.shield <=0){ 
-        destroy(player); 
+    if (player.shield <=0){
+        destroy(player);
         for (let i = 0; i < 500; i++) {
             wait(0.01 *i, ()=>{
-                makeExplosion(vec2(rand(0,MAP_WIDTH,), rand(0, MAP_HEIGHT)), 5, 10, 10); 
+                makeExplosion(vec2(rand(0,MAP_WIDTH,), rand(0, MAP_HEIGHT)), 5, 10, 10);
                 play("explosion", {
-                    detune: rand(-1200, 1200)            
-                });  
-            });   
+                    detune: rand(-1200, 1200)
+                });
+            });
         }
         wait(2, ()=>{
-            go("endGame"); 
-        }); 
+            go("endGame");
+        });
 	}
-}  
+}
 ```
 
-This function has an argument for the number of `shieldPoints` to update the shield by and adjusts the custom `shield` property on the UI layer. It also clamps the minimum and maximum amount the shield can be to between 0 and 100. 
+This function has an argument for the number of `shieldPoints` to update the shield by and adjusts the custom `shield` property on the UI layer. It also clamps the minimum and maximum amount the shield can be to between 0 and 100.
 
 The function sets the width of the `shieldBar` (its dimension along the x axis) to the percentage of the shield available (`player.shield / 100`), multiplied by the full width of the bar, `50`.
 
@@ -670,9 +670,9 @@ Then the function updates the color of the bar depending on the health of the sh
 
 The final step in the shield health function is to check if the shield health is depleted, and end the game if it is.
 
-When the game ends, we destroy the spaceship to remove it from the scene. Now we have another opportunity to create some more explosions using the `makeExplosion` function we added earlier. This time we can go really big! To make a big impact, we create a `for` loop to set off 500 explosions all over the screen for seriously dramatic effect. We use the Kaboom [`wait`](https://kaboomjs.com/doc#wait) function to have a small delay between each explosion so that they don't all go off at once. Then we make each explosion happen at random positions on the map, passing in other parameters to the `makeExplosion` function to set the blast radius, number of sub-explosions and general size. We also play the `explosion` sound effect using Kaboom's [`play`](https://kaboomjs.com/doc#play) function. This time we don't adjust the volume down, as we want the sound to be as dramatic as possible. We detune it randomly again to create a true cacophony and sense of mayhem. 
+When the game ends, we destroy the spaceship to remove it from the scene. Now we have another opportunity to create some more explosions using the `makeExplosion` function we added earlier. This time we can go really big! To make a big impact, we create a `for` loop to set off 500 explosions all over the screen for seriously dramatic effect. We use the Kaboom [`wait`](https://kaboomjs.com/doc#wait) function to have a small delay between each explosion so that they don't all go off at once. Then we make each explosion happen at random positions on the map, passing in other parameters to the `makeExplosion` function to set the blast radius, number of sub-explosions and general size. We also play the `explosion` sound effect using Kaboom's [`play`](https://kaboomjs.com/doc#play) function. This time we don't adjust the volume down, as we want the sound to be as dramatic as possible. We detune it randomly again to create a true cacophony and sense of mayhem.
 
-After setting off all those sound effects and visual fireworks, we [`wait`](https://kaboomjs.com/doc#wait) for 2 seconds for everything to settle down, and then use the Kaboom function [`go`](https://kaboomjs.com/doc#go) to switch to a new scene, `endGame`, and wait for the player to play again. Add the code below to create the `endGame` scene: 
+After setting off all those sound effects and visual fireworks, we [`wait`](https://kaboomjs.com/doc#wait) for 2 seconds for everything to settle down, and then use the Kaboom function [`go`](https://kaboomjs.com/doc#go) to switch to a new scene, `endGame`, and wait for the player to play again. Add the code below to create the `endGame` scene:
 
 ```javascript
 scene("endGame", ()=> {
@@ -693,7 +693,7 @@ scene("endGame", ()=> {
 });
 ```
 
-This scene [`adds`](https://kaboomjs.com/doc#add) a large "GAME OVER" text over the screen until the player presses and releases the `enter` key.  Then the [`keyRelease`](https://kaboomjs.com/doc#keyRelease) event returns the player to the main scene, and uses [`go`](https://kaboomjs.com/doc#go) to switch scenes and restart the game. Because this is a new scene, in a new scope, we need to add the `MAP_WIDTH` and `MAP_HEIGHT` constants again. 
+This scene [`adds`](https://kaboomjs.com/doc#add) a large "GAME OVER" text over the screen until the player presses and releases the `enter` key.  Then the [`keyRelease`](https://kaboomjs.com/doc#keyRelease) event returns the player to the main scene, and uses [`go`](https://kaboomjs.com/doc#go) to switch scenes and restart the game. Because this is a new scene, in a new scope, we need to add the `MAP_WIDTH` and `MAP_HEIGHT` constants again.
 
 ## Allowing the Alien Bugs to Attack
 
@@ -703,67 +703,67 @@ Now that we have mechanisms for updating points and shield health, we can add th
 ```javascript
 const ALIEN_SHIELD_DAMAGE = -15;
 
-collides("alien", "player", (alien, player) =>{
-    shake(20); 
+onCollide("alien", "player", (alien, player) =>{
+    shake(20);
     makeExplosion(alien.pos, 8, 8, 8);
-    destroy(alien); 
-    play("explosion", 
+    destroy(alien);
+    play("explosion",
     {
-      detune: -1200, 
+      detune: -1200,
       volume : 0.5
-    }); 
-    updatePlayerShield(ALIEN_SHIELD_DAMAGE); 
-}); 
+    });
+    updatePlayerShield(ALIEN_SHIELD_DAMAGE);
+});
 ```
 
-This is a big event - it's the way the ship shield gets damaged and it can be fatal - so we want to add a bit more dramatic effect. Kaboom can create a cool screen-shaking effect, as if the player has been hit, which we can invoke by calling [`shake`](https://kaboomjs.com/doc#shake) with a number representing how dramatic the shake should be. Then we add some visual effect with the `makeExplosion` function. We also destroy the alien and [`play`](https://kaboomjs.com/doc#play) the `explosion` effect again, this time a bit louder as the alien exploding has directly affected the player. We also detune the effect to the lowest pitch we can, to make it "feel" more direct, particularly if the player has a sub-woofer. 
+This is a big event - it's the way the ship shield gets damaged and it can be fatal - so we want to add a bit more dramatic effect. Kaboom can create a cool screen-shaking effect, as if the player has been hit, which we can invoke by calling [`shake`](https://kaboomjs.com/doc#shake) with a number representing how dramatic the shake should be. Then we add some visual effect with the `makeExplosion` function. We also destroy the alien and [`play`](https://kaboomjs.com/doc#play) the `explosion` effect again, this time a bit louder as the alien exploding has directly affected the player. We also detune the effect to the lowest pitch we can, to make it "feel" more direct, particularly if the player has a sub-woofer.
 
-Then we call the `updatePlayerShield` function we defined previously, with a constant that defines by how much a shield is damaged per hit. You can move the constant to the top of the main scene file to keep it neat if you want. 
+Then we call the `updatePlayerShield` function we defined previously, with a constant that defines by how much a shield is damaged per hit. You can move the constant to the top of the main scene file to keep it neat if you want.
 
 ## Raining Gems
 
-It's time to add the element that gives the game its purpose: gems the player can collect to earn points. Add this function to create a gem: 
+It's time to add the element that gives the game its purpose: gems the player can collect to earn points. Add this function to create a gem:
 
 
 ```javascript
 function spawnGem(){
-    let xpos = rand(BLOCK_SIZE, MAP_WIDTH - BLOCK_SIZE);  
-    add([ 
+    let xpos = rand(BLOCK_SIZE, MAP_WIDTH - BLOCK_SIZE);
+    add([
 		sprite("gem"),
 		pos(xpos, BLOCK_SIZE),
         area(),
-        body(), 
+        body(),
 		"gem"
 	]);
 }
 
-action("gem", (gem)=>{
+onUpdate("gem", (gem)=>{
     if (gem.pos.y > MAP_HEIGHT) {
-        destroy(gem); 
-        spawnGem(); 
+        destroy(gem);
+        spawnGem();
     }
 
 });
 
-spawnGem(); 
+spawnGem();
 ```
 
-On this weird planet in outer space, the gems rain from the sky, which is the top of the map for our purposes. We calculate a random position, `xpos`, along the `x` axis for the gem to appear on by calling the Kaboom [`rand`](https://kaboomjs.com/doc#rand) function. We don't want the gems to fall right at the edge of the screen, as they will be cut off and the spaceship won't be able to get to them because of the `boundary` elements we added all around the screen. So we limit the random `xpos` to one `BLOCK_SIZE` from each edge. 
+On this weird planet in outer space, the gems rain from the sky, which is the top of the map for our purposes. We calculate a random position, `xpos`, along the `x` axis for the gem to appear on by calling the Kaboom [`rand`](https://kaboomjs.com/doc#rand) function. We don't want the gems to fall right at the edge of the screen, as they will be cut off and the spaceship won't be able to get to them because of the `boundary` elements we added all around the screen. So we limit the random `xpos` to one `BLOCK_SIZE` from each edge.
 
-Now we [`add`](https://kaboomjs.com/doc#add) the gem sprite to the scene. The `pos` component is set to the `xpos` we calculated, with the `y` component set to one `BLOCK_SIZE` from the top of the screen. This is to avoid the gem getting stuck on our upper `boundary`. We also give the gem the [`body`](https://kaboomjs.com/doc#body) component, which makes it subject to Kaboom gravity so that it falls down towards the ground. We give it the label `gem` so that we can refer to it later. 
+Now we [`add`](https://kaboomjs.com/doc#add) the gem sprite to the scene. The `pos` component is set to the `xpos` we calculated, with the `y` component set to one `BLOCK_SIZE` from the top of the screen. This is to avoid the gem getting stuck on our upper `boundary`. We also give the gem the [`body`](https://kaboomjs.com/doc#body) component, which makes it subject to Kaboom gravity so that it falls down towards the ground. We give it the label `gem` so that we can refer to it later.
 
-Then we add the [`action`](https://kaboomjs.com/doc#action) event handler for the gem - we need to do this for all objects with a `body` component so that interactions with [`solid`](https://kaboomjs.com/doc#solid) objects are taken care of. Sometimes, if the frame rate gets too low (if there's a lot of action, or the computer's slow),  some `body` and `solid` interaction maybe missed, and the [`object falls through the solid`](https://github.com/replit/kaboom/issues/86). This could cause gems to fall through the ground, out of reach of the player's spaceship. To account for this possibility, we check if the gem's `y` position is beyond the bounds of the map, and destroy it and spawn a new gem if it is. 
+Then we add the [`onUpdate`](https://kaboomjs.com/doc#onUpdate) event handler for the gem - we need to do this for all objects with a `body` component so that interactions with [`solid`](https://kaboomjs.com/doc#solid) objects are taken care of. Sometimes, if the frame rate gets too low (if there's a lot of action, or the computer's slow),  some `body` and `solid` interaction maybe missed, and the [`object falls through the solid`](https://github.com/replit/kaboom/issues/86). This could cause gems to fall through the ground, out of reach of the player's spaceship. To account for this possibility, we check if the gem's `y` position is beyond the bounds of the map, and destroy it and spawn a new gem if it is.
 
-Finally, we call `spawnGem()` to start the gem raining process. 
+Finally, we call `spawnGem()` to start the gem raining process.
 
 ## Collecting Gems
 
-Now that gems are raining down, we can add a handler to pick up when the player's spaceship moves over a gem. This is how the spaceship "collects" gems, and will earn the player points. Add the following [`collides`](https://kaboomjs.com/doc#collides) event handler:
+Now that gems are raining down, we can add a handler to pick up when the player's spaceship moves over a gem. This is how the spaceship "collects" gems, and will earn the player points. Add the following [`onCollide`](https://kaboomjs.com/doc#onCollide) event handler:
 
 ```javascript
 const POINTS_PER_GEM = 100;
 
-player.collides("gem", (gem) => {
+player.onCollide("gem", (gem) => {
   destroy(gem);
   updateScore(POINTS_PER_GEM);
   wait(1, spawnGem);
@@ -777,7 +777,7 @@ Run the code now and start collecting gems.
 
 ## Adding Background Music
 
-Having sound effects is cool, but games generally need a soundtrack to tie all the sounds together. Kaboom allows us to play a sound file on loop as constant background music. Add this code to the bottom of `main.js` file to play the track: 
+Having sound effects is cool, but games generally need a soundtrack to tie all the sounds together. Kaboom allows us to play a sound file on loop as constant background music. Add this code to the bottom of `main.js` file to play the track:
 
 
 ```javascript
@@ -785,7 +785,7 @@ const music = play("music");
 music.loop();
 ```
 
-The music is a track called "Battle of Pogs" by "Komiku" from ["Free music archive"](https://freemusicarchive.org/music/Komiku/Captain_Glouglous_Incredible_Week_Soundtrack/pog), a good resource for music that you can legally use in your games. 
+The music is a track called "Battle of Pogs" by "Komiku" from ["Free music archive"](https://freemusicarchive.org/music/Komiku/Captain_Glouglous_Incredible_Week_Soundtrack/pog), a good resource for music that you can legally use in your games.
 
 ## Playing the Game
 
@@ -804,7 +804,7 @@ The game art and sounds used in this tutorial are from the following sources:
 - Alien Bug: https://opengameart.org/content/8-bit-alien-assets
 
  The spaceship was made by Ritza.
- 
+
  Thank you to all the creators for putting their assets up with a Creative Commons license and allowing us to use them.
 
 ## Things to Try Next

--- a/tutorials/25-build-3d-game-with-kaboom.md
+++ b/tutorials/25-build-3d-game-with-kaboom.md
@@ -1,8 +1,8 @@
 # Building a pseudo-3D game in Kaboom
 
-Three-dimensional games became popular in the late 80's and early 90's with games like the early Flight Simulator and Wolfenstein 3D. But these early games were really [2.5D, or pseudo-3D](https://en.wikipedia.org/wiki/2.5D): the action takes place in 2 dimensions, and the world only appears to be 3D. 
+Three-dimensional games became popular in the late 80's and early 90's with games like the early Flight Simulator and Wolfenstein 3D. But these early games were really [2.5D, or pseudo-3D](https://en.wikipedia.org/wiki/2.5D): the action takes place in 2 dimensions, and the world only appears to be 3D.
 
-[Kaboom.js](https://kaboomjs.com) is a 2D game engine, but we can use some of those early game designers' techniques to create a pseudo-3D game. This game is roughly based on our [2D space shooter game tutorial](https://docs.replit.com/tutorials/24-build-space-shooter-with-kaboom), but we'll use a view from the cockpit of the spaceship instead of the side-scrolling view. 
+[Kaboom.js](https://kaboomjs.com) is a 2D game engine, but we can use some of those early game designers' techniques to create a pseudo-3D game. This game is roughly based on our [2D space shooter game tutorial](https://docs.replit.com/tutorials/24-build-space-shooter-with-kaboom), but we'll use a view from the cockpit of the spaceship instead of the side-scrolling view.
 
 ![Game functionality](/images/tutorials/25-3d-game-kaboom/gameplay.gif)
 
@@ -15,7 +15,7 @@ Here's what we want from this game:
 - A sense of depth to give the illusion of 3D
 - The feeling of freedom of movement throughout space
 
-We'll make use of Kaboom's [scale component](https://kaboomjs.com/doc#scale) to achieve the sense of depth, representing our sprites as smaller if they are meant to be further away, and larger when they are closer. We'll  create a feeling of moving through space using an algorithm to generate a star field, like the early Windows screensavers. 
+We'll make use of Kaboom's [scale component](https://kaboomjs.com/doc#scale) to achieve the sense of depth, representing our sprites as smaller if they are meant to be further away, and larger when they are closer. We'll  create a feeling of moving through space using an algorithm to generate a star field, like the early Windows screensavers.
 
 ## Creating a new project
 
@@ -41,65 +41,65 @@ To set up the game play environment, click the dropdown next to the Kaboom menu.
 
 Kaboom games are made up of "Scenes", which are like levels, or different parts and stages of a game. The IDE has a default "main" scene already, which we can use for our main game code. Each scene has multiple "Layers", allowing us to have backgrounds that don't affect the game, main game objects (like the player, bullets, enemies, and so on), and UI elements (like the current score and health).
 
-Add the following code to the `main.js` file to create the 3 layers "Background (`bg`)", "Object (`obj`)", "User Interface (`ui`)": 
+Add the following code to the `main.js` file to create the 3 layers "Background (`bg`)", "Object (`obj`)", "User Interface (`ui`)":
 
 ```javascript
 layers([
-    "bg", 
-    "obj", 
-    "ui", 
-], "obj"); 
+    "bg",
+    "obj",
+    "ui",
+], "obj");
 ```
 
 The `obj` layer is set as the default layer and that's where the game action will take place. We'll use the `bg` layer to draw the star field, as we don't interact with the objects on that layer. Then we'll use the `ui` layer to draw fixed foreground objects, like the cockpit of the spaceship the player is travelling in.
 
-## Creating alien bugs 
+## Creating alien bugs
 
-As in the [2D version of this game](https://docs.replit.com/tutorials/24-build-space-shooter-with-kaboom), the point of our game is to avoid and shoot down exploding alien bugs. This time, instead of the bugs coming from the left and right of the screen, we'll make it appear as though they are coming toward the player from "inside" the screen. 
+As in the [2D version of this game](https://docs.replit.com/tutorials/24-build-space-shooter-with-kaboom), the point of our game is to avoid and shoot down exploding alien bugs. This time, instead of the bugs coming from the left and right of the screen, we'll make it appear as though they are coming toward the player from "inside" the screen.
 
 To create this effect, we'll start by making the alien bugs small and spread out over the screen, and have them get bigger and loom toward the center of the screen as they get closer.
 
-We need a 3D coordinate system to work out how our elements should move. We'll create a system like the one in the image below, with 0 for all three dimension axes in the center. This is how we'll track the movements of the aliens in code. When we draw them to the screen, we'll convert these coordinates into the 2D screen coordinate system. 
+We need a 3D coordinate system to work out how our elements should move. We'll create a system like the one in the image below, with 0 for all three dimension axes in the center. This is how we'll track the movements of the aliens in code. When we draw them to the screen, we'll convert these coordinates into the 2D screen coordinate system.
 
 ![3D co-ordinate system](/images/tutorials/25-3d-game-kaboom/3d-system.png)
 
-Let's add the following code to the `main` scene file to achieve this: 
+Let's add the following code to the `main` scene file to achieve this:
 
 ```js
-const SCREEN_WIDTH = 320; 
-const SCREEN_HEIGHT = 200; 
-const ALIEN_SPEED = 200; 
+const SCREEN_WIDTH = 320;
+const SCREEN_HEIGHT = 200;
+const ALIEN_SPEED = 200;
 
 
-let aliens = []; 
+let aliens = [];
 
 function spawnAlien(){
-    const x = rand(0 , SCREEN_WIDTH); 
-    const y = rand(0 , SCREEN_HEIGHT); 
+    const x = rand(0 , SCREEN_WIDTH);
+    const y = rand(0 , SCREEN_HEIGHT);
 
     var newAlien = add([
-        sprite("alien"), 
-        pos(x,y), 
-        scale(0.2), 
+        sprite("alien"),
+        pos(x,y),
+        scale(0.2),
         rotate(0),
         {
-            xpos: rand(-1*SCREEN_WIDTH/2, SCREEN_WIDTH/2), 
+            xpos: rand(-1*SCREEN_WIDTH/2, SCREEN_WIDTH/2),
             ypos: rand(-1*SCREEN_HEIGHT/2, SCREEN_HEIGHT/2),
-            zpos: 1000, 
+            zpos: 1000,
             speed: ALIEN_SPEED + rand(-0.5* ALIEN_SPEED, 0.5*ALIEN_SPEED)
-        }, 
+        },
         "alien"
     ]);
 
-    aliens.push(newAlien); 
+    aliens.push(newAlien);
 }
 
-loop(0.8, spawnAlien); 
+loop(0.8, spawnAlien);
 ```
 
-First, we define some general constants for the size of the screen and the speed at which aliens will move. This way, we don't have to keep remembering and typing numbers, and it's easier to change these aspects later if we need to. We also create an array to hold each alien object we create so that we can keep track of all of them. This will be especially important when we add movement to the aliens. 
+First, we define some general constants for the size of the screen and the speed at which aliens will move. This way, we don't have to keep remembering and typing numbers, and it's easier to change these aspects later if we need to. We also create an array to hold each alien object we create so that we can keep track of all of them. This will be especially important when we add movement to the aliens.
 
-The function `spawnAlien` creates a new alien at a random location on the screen. The first lines calculate a random x and y position to place the alien on the screen initially. This isn't logically needed, as we'll calculate the alien's actual position later from our 3D coordinate system and calculate the projected screen position on each frame. But we need to pass a position [`pos`](https://kaboomjs.com/doc#pos) component to the [`add`](https://kaboomjs.com/doc#add) method when we create a new object, so any random position will do. 
+The function `spawnAlien` creates a new alien at a random location on the screen. The first lines calculate a random x and y position to place the alien on the screen initially. This isn't logically needed, as we'll calculate the alien's actual position later from our 3D coordinate system and calculate the projected screen position on each frame. But we need to pass a position [`pos`](https://kaboomjs.com/doc#pos) component to the [`add`](https://kaboomjs.com/doc#add) method when we create a new object, so any random position will do.
 
 There are two more components we include when constructing the alien object:
 
@@ -108,51 +108,51 @@ There are two more components we include when constructing the alien object:
 
 We also add the coordinates of the alien's position in the 3D system to the alien object as custom properties. We start with a fixed `zpos`, or position on the Z axis, far from the screen.
 
-Then we set the alien's speed, varied by a random amount of up to half the base speed faster or slower so that there's some variety in the way aliens approach the ship. We'll use these custom values when we calculate the alien's position on each frame. 
+Then we set the alien's speed, varied by a random amount of up to half the base speed faster or slower so that there's some variety in the way aliens approach the ship. We'll use these custom values when we calculate the alien's position on each frame.
 
-Finally, we add the new alien to the `aliens` array we created earlier to keep track of it. 
+Finally, we add the new alien to the `aliens` array we created earlier to keep track of it.
 
-Outside the function, we make use of the Kaboom [`loop`](https://kaboomjs.com/doc#loop) functionality to call the `spawnAlien` function to create new aliens at regular intervals. 
+Outside the function, we make use of the Kaboom [`loop`](https://kaboomjs.com/doc#loop) functionality to call the `spawnAlien` function to create new aliens at regular intervals.
 
 ## Moving the alien bugs
 
 Now we need to have the aliens we've generated move with each frame. Here's the code:
 
 ```js
-    action("alien", (alien)=>{
+    onUpdate("alien", (alien)=>{
         alien.zpos -= alien.speed * dt();
 
         alien.scale = 2 - (alien.zpos * 0.002);
 
-        const centerX = SCREEN_WIDTH * 0.5; 
+        const centerX = SCREEN_WIDTH * 0.5;
         const centerY = SCREEN_HEIGHT * 0.25;
 
         alien.pos.x  = centerX + alien.xpos * (alien.zpos * 0.001);
         alien.pos.y = centerY + alien.ypos * (alien.zpos * 0.001);
 
         if (alien.zpos <= 1 ){
-            destroyAlien(alien); 
+            destroyAlien(alien);
         }
-    }); 
+    });
 
     function destroyAlien(alien){
-        aliens = aliens.filter(a => a != alien); 
-        destroy(alien); 
+        aliens = aliens.filter(a => a != alien);
+        destroy(alien);
     }
 ```
 
-First we add a new event handler onto the [`action`](https://kaboomjs.com/doc#action) event, and filter for any objects tagged `alien`. The `action` event handler is fired for each frame. In this event handler function, we adjust the `zpos` of the alien to make it 'move' a little closer to the screen. We use the [`dt()`](https://kaboomjs.com/doc#dt) function to get the time from the last frame, together with the speed per second we assigned to the alien when we constructed it, to calculate the alien's new `zpos` in our 3D coordinate system. We then translate that value to screen coordinates, and mimic the z-axis position by adjusting the size, or `scale`, of the alien sprite. 
+First we add a new event handler onto the [`onUpdate`](https://kaboomjs.com/doc#onUpdate) event, and filter for any objects tagged `alien`. The `onUpdate` event handler is fired for each frame. In this event handler function, we adjust the `zpos` of the alien to make it 'move' a little closer to the screen. We use the [`dt()`](https://kaboomjs.com/doc#dt) function to get the time from the last frame, together with the speed per second we assigned to the alien when we constructed it, to calculate the alien's new `zpos` in our 3D coordinate system. We then translate that value to screen coordinates, and mimic the z-axis position by adjusting the size, or `scale`, of the alien sprite.
 
-Remember that screen coordinates start with (0,0) in the top left corner of the screen, and our 3D coordinate system starts with (0,0,0) in the 'center' of the system. To translate between the 2 systems, we need to find the center of the screen so that we can center the 3D system over it. We do this by by halving the screen `WIDTH` and `HEIGHT` by 2. The screen is the red rectangle in the image below, showing how the 3D system will be centered on it. 
+Remember that screen coordinates start with (0,0) in the top left corner of the screen, and our 3D coordinate system starts with (0,0,0) in the 'center' of the system. To translate between the 2 systems, we need to find the center of the screen so that we can center the 3D system over it. We do this by by halving the screen `WIDTH` and `HEIGHT` by 2. The screen is the red rectangle in the image below, showing how the 3D system will be centered on it.
 
 ![overlay 3d system over 2d system](/images/tutorials/25-3d-game-kaboom/overlay.png)
 
 
 Now we can add the alien's `x` and `y` positions in 3D coordinate space relative to the center point of the screen. We bias the center point "up" a bit, as this will seem to be the center of the spaceship's view when we add the cockpit later. We also modify each of these `x` and `y` positions by a factor relating to the alien's `z` position: As the alien approaches, its `zpos` value decreases, and our factor uses this value to draw the alien nearer to the center of the screen. This enhances the depth illusion and makes it feel to the player that the aliens are coming at them.
 
-Finally, we see if the alien is very close by seeing if the `zpos < 1`. If it is, we destroy the alien to remove it from the scene, as it's either gone past our spaceship or crashed into it. We create a small helper function, `destroyAlien`, to manage this, so that we also remove the alien from the tracking array. 
+Finally, we see if the alien is very close by seeing if the `zpos < 1`. If it is, we destroy the alien to remove it from the scene, as it's either gone past our spaceship or crashed into it. We create a small helper function, `destroyAlien`, to manage this, so that we also remove the alien from the tracking array.
 
-If you run the code now, you should see the aliens start to move toward you. 
+If you run the code now, you should see the aliens start to move toward you.
 
 ![aliens coming at you](/images/tutorials/25-3d-game-kaboom/alieans-coming.gif)
 
@@ -162,9 +162,9 @@ Now that we have the aliens moving and coming at us, let's add another element t
 
 
 ```js
-const STAR_COUNT = 1000; 
-const STAR_SPEED = 5; 
-var stars = []; 
+const STAR_COUNT = 1000;
+const STAR_SPEED = 5;
+var stars = [];
 
 function spawnStars(){
     for (let i = 0; i < STAR_COUNT; i++) {
@@ -177,17 +177,17 @@ function spawnStars(){
     }
 }
 
-spawnStars(); 
+spawnStars();
 
-action(()=>{
-  const centerX = SCREEN_WIDTH * 0.5; 
+onUpdate(()=>{
+  const centerX = SCREEN_WIDTH * 0.5;
   const centerY = SCREEN_HEIGHT * 0.5;
-  
+
   stars.forEach((star)=>{
-    star.zpos -= STAR_SPEED; 
+    star.zpos -= STAR_SPEED;
     if (star.zpos <=1)
     {
-      star.zpos = 1000; 
+      star.zpos = 1000;
     }
     const x = centerX + star.xpos / (star.zpos * 0.001);
     const y = centerY + star.ypos / (star.zpos * 0.001);
@@ -198,7 +198,7 @@ action(()=>{
 
       drawRect(vec2(x,y), 1, 1, {
         color: rgb(intensity, intensity, intensity)
-      });  
+      });
     }
   })
 });
@@ -206,17 +206,17 @@ action(()=>{
 
 While this is very similar to the code we added above for the alien bugs, you'll notice the `spawnStars` function has a few differences to the `spawnAlien` function, such as:
 
-- We create all the stars at once. This is because we need a significant star field to start with, not just a few stars every second. 
-- We don't create a Kaboom object for each star. This is because we don't need the collision handling and other overhead that comes with a Kaboom object, especially since we are generating a lot of stars (`const STAR_COUNT = 1000; `). Instead, we store the stars' info in custom [object literals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Grammar_and_types#object_literals), and add each of these to the `stars` array.  
+- We create all the stars at once. This is because we need a significant star field to start with, not just a few stars every second.
+- We don't create a Kaboom object for each star. This is because we don't need the collision handling and other overhead that comes with a Kaboom object, especially since we are generating a lot of stars (`const STAR_COUNT = 1000; `). Instead, we store the stars' info in custom [object literals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Grammar_and_types#object_literals), and add each of these to the `stars` array.
 - We set the initial `z-pos` of the stars to a random value from 0 to 1000, using the Kaboom [`rand`](https://kaboomjs.com/doc#rand) function. We do this because we create all the stars at once, so we seed the stars at random positions on the z-axis to give the feeling of depth to the star field. If the stars were all initialised to the same `z-pos`, they would move in unison, and it would look like a mass of pixels were coming at us - a bit weird!
 
-Now take a look at the [`action`](https://kaboomjs.com/doc#action) event handler for our stars. It differs from the event handler for our alien bugs in a few ways:
+Now take a look at the [`onUpdate`](https://kaboomjs.com/doc#onUpdate) event handler for our stars. It differs from the event handler for our alien bugs in a few ways:
 
-- We don't use an object filter to look for the stars, as we didn't create them as Kaboom objects. Instead, we just cycle through each star in the `stars` array. 
-- Instead of destroying the star and removing it from the array when it reaches the 'front' of the screen, we recycle it by resetting its `z-pos` back to 1000. 
-- We also check if the star is out of the screen view. If it is, we don't draw it, to save a bit of overhead. 
-- Instead of using the `z-pos` to calculate a value by which to scale the star, we use it to calculate the star's intensity, or brightness. Kaboom uses color values in the range 0-1. So we first scale the `z-pos` down to below 1. Then we subtract it from 1 (the maximum color value, i.e. brightest value) to create an inverse relationship between `z-pos` and intensity. In other words, stars further away from us have higher `zpos` values, giving us lower color intensity. This makes stars far away glow dimly, while those closer to our view look brighter. 
-- Finally, we use the Kaboom's [drawRect](https://kaboomjs.com/doc#drawRect) method to directly draw the star to the screen. As there is no pixel level drawing function in Kaboom, we create a rectangle of size 1 to draw just one pixel. 
+- We don't use an object filter to look for the stars, as we didn't create them as Kaboom objects. Instead, we just cycle through each star in the `stars` array.
+- Instead of destroying the star and removing it from the array when it reaches the 'front' of the screen, we recycle it by resetting its `z-pos` back to 1000.
+- We also check if the star is out of the screen view. If it is, we don't draw it, to save a bit of overhead.
+- Instead of using the `z-pos` to calculate a value by which to scale the star, we use it to calculate the star's intensity, or brightness. Kaboom uses color values in the range 0-1. So we first scale the `z-pos` down to below 1. Then we subtract it from 1 (the maximum color value, i.e. brightest value) to create an inverse relationship between `z-pos` and intensity. In other words, stars further away from us have higher `zpos` values, giving us lower color intensity. This makes stars far away glow dimly, while those closer to our view look brighter.
+- Finally, we use the Kaboom's [drawRect](https://kaboomjs.com/doc#drawRect) method to directly draw the star to the screen. As there is no pixel level drawing function in Kaboom, we create a rectangle of size 1 to draw just one pixel.
 
 ## Adding the spaceship cockpit
 
@@ -225,17 +225,17 @@ Now that we have a star field to fly through, let's add the player's spaceship. 
 ```js
     const cockpit = add([
         sprite("cockpit"),
-        layer("ui"), 
+        layer("ui"),
         rotate(0),
         pos(SCREEN_WIDTH/2, SCREEN_HEIGHT/2 ),
-        origin("center"), 
+        origin("center"),
         scale(0.275)
     ]);
 ```
 
-This adds the `cockpit` sprite (image) to the `ui` layer. We also add the [`rotate`](https://kaboomjs.com/doc#rotate) component to it, so that we can add some rotation effects when the spaceship is flying. We use the [`origin`](https://kaboomjs.com/doc#origin) component to center the image in the middle of the screen, which also provides the axis to rotate the sprite around when banking (turning) the spaceship. Then we use a scaling factor to [`scale`](https://kaboomjs.com/doc#scale) the image down to the size of the screen. We scale the image as it's much larger (1334×834) than the size of the game screen (320x200). We could resize the image in an image editing programme, but we would lose some detail and sharpness. Note that the factor of the scale means that the image is still a little larger than the screen size. This gives us a bit of overlap available for when we rotate the image when banking the spaceship. 
+This adds the `cockpit` sprite (image) to the `ui` layer. We also add the [`rotate`](https://kaboomjs.com/doc#rotate) component to it, so that we can add some rotation effects when the spaceship is flying. We use the [`origin`](https://kaboomjs.com/doc#origin) component to center the image in the middle of the screen, which also provides the axis to rotate the sprite around when banking (turning) the spaceship. Then we use a scaling factor to [`scale`](https://kaboomjs.com/doc#scale) the image down to the size of the screen. We scale the image as it's much larger (1334×834) than the size of the game screen (320x200). We could resize the image in an image editing programme, but we would lose some detail and sharpness. Note that the factor of the scale means that the image is still a little larger than the screen size. This gives us a bit of overlap available for when we rotate the image when banking the spaceship.
 
-Run the game now and you should see the view from inside the spaceship. 
+Run the game now and you should see the view from inside the spaceship.
 
 ![spaceship view](/images/tutorials/25-3d-game-kaboom/spaceship-view.gif)
 
@@ -244,80 +244,80 @@ Run the game now and you should see the view from inside the spaceship.
 
 Our basic game world is up and running, now let's add some controls so we can move around in it. We'll allow a few different moves for the spaceship: bank left or right, and fly up or down.
 
-Consider for a moment how the spaceship moves through the game world. We can't move the cockpit left or right, up or down - it would just disappear off the screen. One way of simulating movement from the point of view of the cockpit is to keep it stationary and move all the other game elements. 
+Consider for a moment how the spaceship moves through the game world. We can't move the cockpit left or right, up or down - it would just disappear off the screen. One way of simulating movement from the point of view of the cockpit is to keep it stationary and move all the other game elements.
 
 To achieve this, let's add some helper functions to move the game objects. Here's the code:
 
 ```js
 function shiftAliens(x, y){
     aliens.forEach((alien) =>{
-        alien.xpos += x / (alien.zpos*0.01); 
-        alien.ypos += y / (alien.zpos*0.01);  
-    }); 
+        alien.xpos += x / (alien.zpos*0.01);
+        alien.ypos += y / (alien.zpos*0.01);
+    });
 }
 
 function shiftStars(x, y){
     stars.forEach(star =>{
-        star.xpos += x *0.01; 
-        star.ypos += y *0.01; 
+        star.xpos += x *0.01;
+        star.ypos += y *0.01;
     });
 }
-``` 
-These 2 functions take `x` and `y` values for the amount we want to "move" by, and uses these to move the aliens and the stars. In each case, we loop through the arrays holding the alien or star game objects. We make some adjustments to the values supplied to the functions to account for the perception that, when we move, objects further away appear to move "less" than objects close to us. In the case of the stars, we assume they are all in the far distance, so we scale down the amounts to move by a constant factor. In the case of the aliens, some are far away, while others are right up against the spaceship. To account for this variance, we adjust the amount to move an alien by a factor related to its distance from us, or `zpos`. Aliens close by will appear to move more than those far away. 
+```
+These 2 functions take `x` and `y` values for the amount we want to "move" by, and uses these to move the aliens and the stars. In each case, we loop through the arrays holding the alien or star game objects. We make some adjustments to the values supplied to the functions to account for the perception that, when we move, objects further away appear to move "less" than objects close to us. In the case of the stars, we assume they are all in the far distance, so we scale down the amounts to move by a constant factor. In the case of the aliens, some are far away, while others are right up against the spaceship. To account for this variance, we adjust the amount to move an alien by a factor related to its distance from us, or `zpos`. Aliens close by will appear to move more than those far away.
 
-Now we can add some event handlers for keyboard input: 
+Now we can add some event handlers for keyboard input:
 
 ```js
-    const MOVE_DELTA = 2000; 
+    const MOVE_DELTA = 2000;
 
-    keyDown("left", () => {
-        const delta =  MOVE_DELTA * dt(); 
+    onKeyDown("left", () => {
+        const delta =  MOVE_DELTA * dt();
         shiftAliens(delta, 0);
         shiftStars(delta*0.01, 0);
         camRot(0.1);
     });
 
-    keyDown("right", () => {
-        const delta =  -1 * MOVE_DELTA * dt(); 
+    onKeyDown("right", () => {
+        const delta =  -1 * MOVE_DELTA * dt();
         shiftAliens(delta, 0);
         shiftStars(delta*0.01, 0);
         camRot(-0.1);
     });
 
 
-    keyDown("up", () => {
-        const delta =  -1 * MOVE_DELTA * dt(); 
+    onKeyDown("up", () => {
+        const delta =  -1 * MOVE_DELTA * dt();
         shiftAliens(0, delta);
         shiftStars(0,delta*0.01);
     });
 
-    keyDown("down", () => {
+    onKeyDown("down", () => {
         const delta = MOVE_DELTA * dt();
         shiftAliens(0, delta);
         shiftStars(0, delta*0.01);
     });
 
-    keyRelease("left", ()=>{
+    onKeyRelease("left", ()=>{
         camRot(0);
-    }); 
+    });
 
-    keyRelease("right", ()=>{
+    onKeyRelease("right", ()=>{
         camRot(0);
-    }); 
+    });
 ```
 
-Because we're moving the aliens and stars to make it appear as if the spaceship is moving, these elements must move in the opposite direction to that of the arrow key being used. When we use the left key to move the spaceship, our scene moves to the right. We use the Kaboom events [`keyDown`](https://kaboomjs.com/doc#keyDown) and [`keyRelease`](https://kaboomjs.com/doc#keyRelease) to attach event handlers for direction controls to the arrow keys on the keyboard. In each of the `keyDown` event handlers, we get the time elapsed from the last frame by calling the [`dt()`](https://kaboomjs.com/doc#dt) function, and multiply it by a constant `MOVE_DELTA`, representing the amount to move by each second. For the `right` and `up` keys, our elements move left and down respectively, so we make the amount to move negative - recall that we are moving the objects in our 3D coordinate system. Then we call the 2 helper functions we defined above with the amount to move the objects in the `x` and `y` dimensions. 
+Because we're moving the aliens and stars to make it appear as if the spaceship is moving, these elements must move in the opposite direction to that of the arrow key being used. When we use the left key to move the spaceship, our scene moves to the right. We use the Kaboom events [`onKeyDown`](https://kaboomjs.com/doc#onKeyDown) and [`onKeyRelease`](https://kaboomjs.com/doc#onKeyRelease) to attach event handlers for direction controls to the arrow keys on the keyboard. In each of the `onKeyDown` event handlers, we get the time elapsed from the last frame by calling the [`dt()`](https://kaboomjs.com/doc#dt) function, and multiply it by a constant `MOVE_DELTA`, representing the amount to move by each second. For the `right` and `up` keys, our elements move left and down respectively, so we make the amount to move negative - recall that we are moving the objects in our 3D coordinate system. Then we call the 2 helper functions we defined above with the amount to move the objects in the `x` and `y` dimensions.
 
-In the event handlers for `left` and `right` keys, we also make use of the Kaboom [`camRot`](https://kaboomjs.com/doc#camRot) effect. This effect rotates all objects by the amount we specify, giving the perception of the spaceship banking hard while turning. We add in two additional event handlers on [`keyRelease`](https://kaboomjs.com/doc#keyRelease) for the `left` and `right` keys to reset the rotation when the player stops turning. 
+In the event handlers for `left` and `right` keys, we also make use of the Kaboom [`camRot`](https://kaboomjs.com/doc#camRot) effect. This effect rotates all objects by the amount we specify, giving the perception of the spaceship banking hard while turning. We add in two additional event handlers on [`onKeyRelease`](https://kaboomjs.com/doc#onKeyRelease) for the `left` and `right` keys to reset the rotation when the player stops turning.
 
-Give the game a run, and you should be able to control the spaceship. 
+Give the game a run, and you should be able to control the spaceship.
 
 ![flying controls](/images/tutorials/25-3d-game-kaboom/fly-controls.gif)
 
 
 ## Adding weapons
 
-Now we're flying through the alien bug field, but if an alien makes contact with our spaceship, it will explode and damage us. We need some weapons to shoot the aliens with and protect ourselves. For this, we need to implement some lasers. First, let's add cross hairs to aim with: 
+Now we're flying through the alien bug field, but if an alien makes contact with our spaceship, it will explode and damage us. We need some weapons to shoot the aliens with and protect ourselves. For this, we need to implement some lasers. First, let's add cross hairs to aim with:
 
 ```js
 const vertical_crosshair = add([
@@ -337,9 +337,9 @@ const horizontal_crosshair = add([
 ]);
 
 ```
-This adds 2 lines at a point halfway across the screen, and about 1/3 down the screen, which is roughly the center of the view out of the spaceship window. Since Kaboom doesn't have a line component, we use [`rect`](https://kaboomjs.com/doc#rect) to draw rectangles with a width of 1 pixel, effectively a line. We add the cross hairs to the UI layer, so they are always on top of the aliens and stars. 
+This adds 2 lines at a point halfway across the screen, and about 1/3 down the screen, which is roughly the center of the view out of the spaceship window. Since Kaboom doesn't have a line component, we use [`rect`](https://kaboomjs.com/doc#rect) to draw rectangles with a width of 1 pixel, effectively a line. We add the cross hairs to the UI layer, so they are always on top of the aliens and stars.
 
-Now we have a point to aim at, let's add the lasers. Our player will shoot using the spacebar, and we want a classic laser effect: 2 lasers, one shooting from each side of the ship towards the same point to give the effect of shooting into the distance, towards a vanishing point. 
+Now we have a point to aim at, let's add the lasers. Our player will shoot using the spacebar, and we want a classic laser effect: 2 lasers, one shooting from each side of the ship towards the same point to give the effect of shooting into the distance, towards a vanishing point.
 
 ```js
 
@@ -347,10 +347,10 @@ Now we have a point to aim at, let's add the lasers. Our player will shoot using
 const BULLET_SPEED = 10;
 function spawnBullet() {
 
-    const BULLET_ORIGIN_LEFT = vec2(SCREEN_WIDTH *0.25, (SCREEN_HEIGHT - SCREEN_HEIGHT*0.33)); 
-    const BULLET_ORIGIN_RIGHT = vec2(SCREEN_WIDTH - (SCREEN_WIDTH*0.25), (SCREEN_HEIGHT - SCREEN_HEIGHT*0.33)); 
+    const BULLET_ORIGIN_LEFT = vec2(SCREEN_WIDTH *0.25, (SCREEN_HEIGHT - SCREEN_HEIGHT*0.33));
+    const BULLET_ORIGIN_RIGHT = vec2(SCREEN_WIDTH - (SCREEN_WIDTH*0.25), (SCREEN_HEIGHT - SCREEN_HEIGHT*0.33));
 
-    const BULLET_VANISHING_POINT = vec2(SCREEN_WIDTH * 0.5, SCREEN_HEIGHT *0.33); 
+    const BULLET_VANISHING_POINT = vec2(SCREEN_WIDTH * 0.5, SCREEN_HEIGHT *0.33);
 
     add([
         rect(1, 1),
@@ -358,7 +358,7 @@ function spawnBullet() {
         color(1, 0, 0),
         "bullet",
         {
-            bulletSpeed:  BULLET_SPEED , 
+            bulletSpeed:  BULLET_SPEED ,
             targetPos: BULLET_VANISHING_POINT
         }
     ]);
@@ -369,7 +369,7 @@ function spawnBullet() {
         color(1, 0, 0),
         "bullet",
         {
-            bulletSpeed:  -1*BULLET_SPEED, 
+            bulletSpeed:  -1*BULLET_SPEED,
             targetPos: BULLET_VANISHING_POINT
         }
     ]);
@@ -381,24 +381,24 @@ function spawnBullet() {
 }
 ```
 
-When the player fires, we call the `spawnBullet` function to create a new set of laser bullets. First, we calculate the position the bullets will be coming from. To make it seem as though they're coming from under the spaceship either side, we calculate our bullets' starting positions a quarter way from each side of the screen and about a third of the way from the bottom using the multipliers `0.25` and `0.33` respectively. 
+When the player fires, we call the `spawnBullet` function to create a new set of laser bullets. First, we calculate the position the bullets will be coming from. To make it seem as though they're coming from under the spaceship either side, we calculate our bullets' starting positions a quarter way from each side of the screen and about a third of the way from the bottom using the multipliers `0.25` and `0.33` respectively.
 
-Then we calculate where we want the bullets to end up. This is the same position as the cross hairs.  
+Then we calculate where we want the bullets to end up. This is the same position as the cross hairs.
 
 Using these values, we create 2 bullet objects - simple 1 pixel objects with the tag `bullet` and color set to red `(1,0,0)` so they look menacing. We also add custom properties to the object: A speed for the bullet to move at, and the vanishing point where its course ends.
 
 As a final detail, we set our "shoot" sound to play as each bullet is created, adjusting the volume and applying a randomly generated detune value so that the pitch of the sound is slightly different each time it's played.
 
-We've got our bullets, their sounds and their trajectories, so let's make them go from their origin point to the vanishing point at the cross hairs by moving them with each frame: 
+We've got our bullets, their sounds and their trajectories, so let's make them go from their origin point to the vanishing point at the cross hairs by moving them with each frame:
 
 ```js
-action("bullet", (b) => {
+onUpdate("bullet", (b) => {
 
-    const m = (b.pos.y - b.targetPos.y) / (b.pos.x - b.targetPos.x); 
-    const c = b.targetPos.y - m*(b.targetPos.x); 
+    const m = (b.pos.y - b.targetPos.y) / (b.pos.x - b.targetPos.x);
+    const c = b.targetPos.y - m*(b.targetPos.x);
 
-    let newX = b.pos.x + b.bulletSpeed; 
-    let newY = m * newX + c; 
+    let newX = b.pos.x + b.bulletSpeed;
+    let newY = m * newX + c;
     b.pos.x = newX
     b.pos.y = newY;
     // Remove the bullet once it has hit the vanishing point y line
@@ -407,12 +407,12 @@ action("bullet", (b) => {
     }
 });
 
-keyDown("space", () => {
-    spawnBullet(); 
+onKeyDown("space", () => {
+    spawnBullet();
 });
 
 ```
-Here we use the [`action`](https://kaboomjs.com/doc#action) event handler, filtered to `bullet` objects.
+Here we use the [`onUpdate`](https://kaboomjs.com/doc#onUpdate) event handler, filtered to `bullet` objects.
 
 To calculate the bullet's next position on its trajectory for each frame, we need to find the values for the slope (`m`) and y-intercept (in this case, `c`) of the straight line between the bullet's current position and its end position. Our first 2 lines of the function express those variable parameters as formulas. Let's take a moment to see how we came to those formulas.
 
@@ -422,7 +422,7 @@ We began with the [equation for a straight line](https://www.mathsisfun.com/equa
 y = m*x + c
 ```
 
-Since we have the `x` and `y` coordinates for the start and end of the trajectory, we can use them to find the values of the unknowns `m` and `c` by solving simultaneous equations: 
+Since we have the `x` and `y` coordinates for the start and end of the trajectory, we can use them to find the values of the unknowns `m` and `c` by solving simultaneous equations:
 
 ```
 y_start = m*x_start + c         (1)
@@ -445,33 +445,33 @@ Now that we can express `m` and `c` as formulas, we use them in our code to calc
 
 Our code goes on to advance the bullet's current `x` position by the bullet speed amount, and we can figure out the corresponding new `y` position using the `m` and `c` values calculated above with our new `x` position. We then update the bullet's new position (`pos`) with these new values.
 
-We want the bullets to disappear once they hit the target at the vanishing point, so we go on to check if the bullet has crossed the horizontal cross hairs. If it has, we remove the bullet from the scene using the [`destroy`](https://kaboomjs.com/doc#destroy) function. 
+We want the bullets to disappear once they hit the target at the vanishing point, so we go on to check if the bullet has crossed the horizontal cross hairs. If it has, we remove the bullet from the scene using the [`destroy`](https://kaboomjs.com/doc#destroy) function.
 
-Finally, we have an event handler for the `space` key, which calls the `spawnBullet` function whenever it is pressed. 
+Finally, we have an event handler for the `space` key, which calls the `spawnBullet` function whenever it is pressed.
 
-Try this out now, and you should be able to shoot some laser bullets into space. 
+Try this out now, and you should be able to shoot some laser bullets into space.
 
 ![Shooting](/images/tutorials/25-3d-game-kaboom/shooting.gif)
 
 
 ## Checking for collisions with bullets
 
-Now that we can shoot bullets, we need to check if they hit an alien bug. If they did, we explode the alien. 
+Now that we can shoot bullets, we need to check if they hit an alien bug. If they did, we explode the alien.
 
 ```js
-const BULLET_SLACK = 10; 
-collides("alien","bullet", (alien, bullet) =>{
-    if (bullet.pos.y > SCREEN_HEIGHT*0.33 + BULLET_SLACK) return; 
+const BULLET_SLACK = 10;
+onCollide("alien","bullet", (alien, bullet) =>{
+    if (bullet.pos.y > SCREEN_HEIGHT*0.33 + BULLET_SLACK) return;
     makeExplosion(bullet.pos, 5, 5, 5);
-    destroy(alien); 
-    destroy(bullet);  
-}); 
+    destroy(alien);
+    destroy(bullet);
+});
 
 ```
 
-We make use of the Kaboom event [`collides`](https://kaboomjs.com/doc#collides) which is fired when 2 game objects are overlapping or touching each other. We pass in the tags for the aliens and bullets, so we know when they collide.
+We make use of the Kaboom event [`onCollide`](https://kaboomjs.com/doc#onCollide) which is fired when 2 game objects are overlapping or touching each other. We pass in the tags for the aliens and bullets, so we know when they collide.
 
-We want to limit bullet hits to only be around the target area, so that the 3D perspective is kept. But because they could collide at any point along the path the bullet takes, we check if the collision has taken place at around the cross hairs area. Then, if is in the target zone, we remove both the bullet and the alien from the scene, and call a function to create an explosion effect. This is the same code used in the [2D Space Shooter tutorial](https://docs.replit.com/tutorials/24-build-space-shooter-with-kaboom). 
+We want to limit bullet hits to only be around the target area, so that the 3D perspective is kept. But because they could collide at any point along the path the bullet takes, we check if the collision has taken place at around the cross hairs area. Then, if is in the target zone, we remove both the bullet and the alien from the scene, and call a function to create an explosion effect. This is the same code used in the [2D Space Shooter tutorial](https://docs.replit.com/tutorials/24-build-space-shooter-with-kaboom).
 
 ```js
 function makeExplosion(p, n, rad, size) {
@@ -514,50 +514,50 @@ function grow(rate) {
 }
 
 ```
-We won't explain this code here, but if you'd like to know how it works, visit the [2D Space Shooter tutorial](https://docs.replit.com/tutorials/24-build-space-shooter-with-kaboom) to learn more. 
+We won't explain this code here, but if you'd like to know how it works, visit the [2D Space Shooter tutorial](https://docs.replit.com/tutorials/24-build-space-shooter-with-kaboom) to learn more.
 
-Run this now, and you should be able to shoot the alien bugs down. 
+Run this now, and you should be able to shoot the alien bugs down.
 
 ![Shooting explosions](/images/tutorials/25-3d-game-kaboom/shooting-explosion.gif)
 
 
 ## Checking if alien bugs hit the spaceship
 
-Now we can add functionality to check if an alien bug makes it past our laser and explodes into the spaceship. Since the cockpit covers the entire screen, we can't make use of the [`collides`](https://kaboomjs.com/doc#collides) function to check if an alien has hit the cockpit, as it would always be colliding. Instead, we can check the `z` value of the alien, plus if it is within an area of the spacecraft that would cause damage. We'll use a "strike zone" in the center of the cockpit view as the area that aliens can do damage to the craft. Outside that area, we'll assume that the aliens go around or up and over the spacecraft. 
+Now we can add functionality to check if an alien bug makes it past our laser and explodes into the spaceship. Since the cockpit covers the entire screen, we can't make use of the [`onCollide`](https://kaboomjs.com/doc#onCollide) function to check if an alien has hit the cockpit, as it would always be colliding. Instead, we can check the `z` value of the alien, plus if it is within an area of the spacecraft that would cause damage. We'll use a "strike zone" in the center of the cockpit view as the area that aliens can do damage to the craft. Outside that area, we'll assume that the aliens go around or up and over the spacecraft.
 
-To implement this scheme, add a definition for the strike zone: 
+To implement this scheme, add a definition for the strike zone:
 
 ```js
 const STRIKE_ZONE = {x1:80, x2:240, y1:20, y2:100};
 
 ```
 
-Then we can modify the `action("alien",....)` event handler that we added earlier in **"Moving the Alien Bugs"** section. In the part of the function where we check if the alien is close to us (`if (alien.zpos <= 1 )`), update the code as follows:
+Then we can modify the `onUpdate("alien",....)` event handler that we added earlier in **"Moving the Alien Bugs"** section. In the part of the function where we check if the alien is close to us (`if (alien.zpos <= 1 )`), update the code as follows:
 
 ```js
    if (alien.zpos < 1 ){
-        //check if the alien has hit the craft 
-        if (alien.pos.x >= STRIKE_ZONE.x1 && 
-            alien.pos.x <= STRIKE_ZONE.x2 && 
-            alien.pos.y >= STRIKE_ZONE.y1 && 
+        //check if the alien has hit the craft
+        if (alien.pos.x >= STRIKE_ZONE.x1 &&
+            alien.pos.x <= STRIKE_ZONE.x2 &&
+            alien.pos.y >= STRIKE_ZONE.y1 &&
             alien.pos.y <= STRIKE_ZONE.y2){
-                camShake(20); 
+                camShake(20);
                 makeExplosion(alien.pos, 10, 10, 10);
         }
-        destroyAlien(alien); 
+        destroyAlien(alien);
     }
 ```
 
-We've modified the code to check if the alien is really close to us (`alien.zpos < 1 `), and if it is, we check if it is within the bounds of the `STRIKE_ZONE` area. The strike zone is a rectangle - you could implement more complex shapes if you wanted to be more accurate about where the alien can hit. However, a rectangle approximation is OK for this game. 
+We've modified the code to check if the alien is really close to us (`alien.zpos < 1 `), and if it is, we check if it is within the bounds of the `STRIKE_ZONE` area. The strike zone is a rectangle - you could implement more complex shapes if you wanted to be more accurate about where the alien can hit. However, a rectangle approximation is OK for this game.
 
-If the alien is close enough, and within our strike zone, we use the [`camShake`](https://kaboomjs.com/doc#camShake) effect to make it "feel" like we've been hit. Then we create an explosion at the point of impact for some visual effects. 
+If the alien is close enough, and within our strike zone, we use the [`camShake`](https://kaboomjs.com/doc#camShake) effect to make it "feel" like we've been hit. Then we create an explosion at the point of impact for some visual effects.
 
 ![Colliding](/images/tutorials/25-3d-game-kaboom/colliding.gif)
 
 
 ## Finishing up the game
 
-Congratulations, we've got all the main elements of flying and shooting and damage in the game. The next thing to do would be to add a scoring system, and a way to reduce the spaceship's health or shield when it gets hit. You can look at the [tutorial for the 2D version of this game](https://docs.replit.com/tutorials/24-build-space-shooter-with-kaboom), and copy the scoring and health code from there into this game. You can also copy the code for background music and more sound effects. 
+Congratulations, we've got all the main elements of flying and shooting and damage in the game. The next thing to do would be to add a scoring system, and a way to reduce the spaceship's health or shield when it gets hit. You can look at the [tutorial for the 2D version of this game](https://docs.replit.com/tutorials/24-build-space-shooter-with-kaboom), and copy the scoring and health code from there into this game. You can also copy the code for background music and more sound effects.
 
 Happy coding and have fun!
 

--- a/tutorials/27-build-tictactoe-with-websockets-kaboom.md
+++ b/tutorials/27-build-tictactoe-with-websockets-kaboom.md
@@ -1,8 +1,8 @@
 # Building tic-tac-toe with WebSocket and Kaboom.js
 
-Tic-tac-toe, or noughts and crosses, or Xs and Os, is a simple classic game for 2 players. It's usually played with paper and pen, but it also makes a good first game to write for networked multiplayer. 
+Tic-tac-toe, or noughts and crosses, or Xs and Os, is a simple classic game for 2 players. It's usually played with paper and pen, but it also makes a good first game to write for networked multiplayer.
 
-In this tutorial, we'll create a 2-player online tic-tac-toe game using a [Node.js](https://nodejs.org/en/) server. [Socket.IO](https://socket.io) will enable realtime gameplay across the internet. We'll use Kaboom.js to create the game interface. 
+In this tutorial, we'll create a 2-player online tic-tac-toe game using a [Node.js](https://nodejs.org/en/) server. [Socket.IO](https://socket.io) will enable realtime gameplay across the internet. We'll use Kaboom.js to create the game interface.
 
 ![Game play](/images/tutorials/27-tictactoe-kaboom/gameplay.gif)
 
@@ -12,13 +12,13 @@ Multiplayer games have an architecture that typically looks something like this:
 
 ![Game server architecture](/images/tutorials/27-tictactoe-kaboom/architecture.png)
 
-Players (clients) connect to a _game server_ over the internet. The game runs on the game server, where all the game rules, scores and other data are processed. The players' computers render the graphics for the game, and send player commands (from the keyboard, mouse, gamepad, or other input device) back to the game server. The game server checks if these commands are valid, and then updates the _game state_. The game state is a representation of all the variables, players, data and information about the game. This game state is then transmitted back to all the players and the graphics are updated. 
+Players (clients) connect to a _game server_ over the internet. The game runs on the game server, where all the game rules, scores and other data are processed. The players' computers render the graphics for the game, and send player commands (from the keyboard, mouse, gamepad, or other input device) back to the game server. The game server checks if these commands are valid, and then updates the _game state_. The game state is a representation of all the variables, players, data and information about the game. This game state is then transmitted back to all the players and the graphics are updated.
 
 A lot of communication needs to happen between a player's computer and the game server in online multiplayer games. This generally requires a 2-way, or _bidirectional_, link so that the game server can send data and notify players of updates to the game state. This link should ideally be quick too, so a more permanent connection is better.
 
-With the [HTTP](https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol) protocol that websites usually use, a browser opens a connection to a server, then makes a request to the server, and the server sends back data, and closes the connection. There is no way for the server to initiate sending data to the browser. HTTP is also heavy on overhead, since it opens and closes a connection each time data is requested and sent. 
+With the [HTTP](https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol) protocol that websites usually use, a browser opens a connection to a server, then makes a request to the server, and the server sends back data, and closes the connection. There is no way for the server to initiate sending data to the browser. HTTP is also heavy on overhead, since it opens and closes a connection each time data is requested and sent.
 
-[WebSocket](https://en.wikipedia.org/wiki/WebSocket) is an advanced internet protocol that allows us to create a 2-way, persistent connection between a browser and a server. We'll use the [Socket.IO](https://socket.io) package to help us manage WebSocket connections in this project. 
+[WebSocket](https://en.wikipedia.org/wiki/WebSocket) is an advanced internet protocol that allows us to create a 2-way, persistent connection between a browser and a server. We'll use the [Socket.IO](https://socket.io) package to help us manage WebSocket connections in this project.
 
 ## Creating a new project
 
@@ -28,11 +28,11 @@ For this project, we'll need to create 2 repls - 1 using Node.js for the game se
 - To create the player project, choose "Kaboom" as your project type. Give this repl a name, like "tic-tac-toe".
   ![New Player repl](/images/tutorials/27-tictactoe-kaboom/player-new-repl.png)
 
-We'll code in the server repl to start, and then switch between repls as we build the game. 
+We'll code in the server repl to start, and then switch between repls as we build the game.
 
 ## Setting up Socket.IO on the server
 
-Add the following code to the file called `index.js` in the server project to import Socket.IO: 
+Add the following code to the file called `index.js` in the server project to import Socket.IO:
 
 ```js
 const http = require('http');
@@ -52,17 +52,17 @@ server.listen(3000, function() {
 
 ```
 
-In the first 2 lines, we import the built-in node [`http`](https://nodejs.org/api/http.html) package and the [`socket.io`](https://socket.io) package. The `http` package enables us to run a simple HTTP server. The `socket.io` package extends that server to add [WebSocket](https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API) functionality. 
+In the first 2 lines, we import the built-in node [`http`](https://nodejs.org/api/http.html) package and the [`socket.io`](https://socket.io) package. The `http` package enables us to run a simple HTTP server. The `socket.io` package extends that server to add [WebSocket](https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API) functionality.
 
-To create the HTTP server, we use the `http.createServer();` method. Then we set up Socket.IO by creating a new `io` object. We pass in the HTTP server object along with some configuration for [CORS](https://developer.mozilla.org/en-US/docs/Glossary/CORS). CORS stands for "Cross Origin Resource Sharing", and it's a system that tells the server which other sites are allowed to connect to it and access it. We set `origin` to allow our player repl to connect. Replace the `origin` value with the URL of the player project repl you set up earlier. 
+To create the HTTP server, we use the `http.createServer();` method. Then we set up Socket.IO by creating a new `io` object. We pass in the HTTP server object along with some configuration for [CORS](https://developer.mozilla.org/en-US/docs/Glossary/CORS). CORS stands for "Cross Origin Resource Sharing", and it's a system that tells the server which other sites are allowed to connect to it and access it. We set `origin` to allow our player repl to connect. Replace the `origin` value with the URL of the player project repl you set up earlier.
 
 In the last 2 lines, we start the server up by calling its `listen` method, along with a port to listen on. We use 3000, as this is a standard for Node.js. If it starts successfully, we write a message to the console to let us know.
 
-We'll add the rest of the server code above the `server.listen` line, as we only want to start the server up after all the other code is ready. 
+We'll add the rest of the server code above the `server.listen` line, as we only want to start the server up after all the other code is ready.
 
 ## Tracking the game state
 
-Now that we have a server, lets think a bit about how we will represent, or model, the game. Our tic-tac-toe game will have a few different properties to track: 
+Now that we have a server, lets think a bit about how we will represent, or model, the game. Our tic-tac-toe game will have a few different properties to track:
 
 - The status of the game: What is currently happening? Are we waiting for players to join, are the players playing, or is the game over?
 - The current positions on the tic-tac-toe board. Is there a player in a grid block, or is it empty?
@@ -70,18 +70,18 @@ Now that we have a server, lets think a bit about how we will represent, or mode
 - The current player. Whose turn is it to go?
 - If the game ends in a win, who won it?
 
-For the status of the game, we'll add an [enumeration](https://masteringjs.io/tutorials/fundamentals/enum) of the possible states we can expect. This makes it easier to track and use them as we go through the different phases of the game. 
+For the status of the game, we'll add an [enumeration](https://masteringjs.io/tutorials/fundamentals/enum) of the possible states we can expect. This makes it easier to track and use them as we go through the different phases of the game.
 
 ```js
 const Statuses = {
-  WAITING: 'waiting', 
-  PLAYING: 'playing', 
-  DRAW: 'draw', 
+  WAITING: 'waiting',
+  PLAYING: 'playing',
+  DRAW: 'draw',
   WIN: 'win'
 }
 ```
 
-- WAITING: We are waiting for all the players to join the game. 
+- WAITING: We are waiting for all the players to join the game.
 - PLAYING: The players can make moves on the board.
 - DRAW: The game has ended in a draw.
 - WIN: A player has won the game.
@@ -90,9 +90,9 @@ Now let's add a game state object to track everything:
 
 ```js
 let gameState = {
-  board: new Array(9).fill(null), 
+  board: new Array(9).fill(null),
   currentPlayer: null,
-  players : [], 
+  players : [],
   result : {
     status : Statuses.WAITING
   }
@@ -104,36 +104,36 @@ First, we have a representation of the tic-tac-toe board as an array with 9 elem
 ![Tic Tac Toe board mapped to array indices](/images/tutorials/27-tictactoe-kaboom/board.png)
 
 
-Each number in the blocks represents the index at which the board position is represented in the array. Initially, we fill all the elements of the array with `null` to indicate that the block is open. When players make a move to occupy an open space, we'll add a reference to the player instead. That way we can keep track of which blocks are empty, and which are occupied by which player. 
+Each number in the blocks represents the index at which the board position is represented in the array. Initially, we fill all the elements of the array with `null` to indicate that the block is open. When players make a move to occupy an open space, we'll add a reference to the player instead. That way we can keep track of which blocks are empty, and which are occupied by which player.
 
-Next, we have `currentPlayer`, which we will alternately set to each player when it's their turn to move. 
+Next, we have `currentPlayer`, which we will alternately set to each player when it's their turn to move.
 
-Then there is an array called `players`, which will hold references to both of the players in the game. This will allow us to show the names of the players on screen, as well as generally keep track of the players. 
+Then there is an array called `players`, which will hold references to both of the players in the game. This will allow us to show the names of the players on screen, as well as generally keep track of the players.
 
-The `result` field is updated after every move. This field will contain the status of the game (as we defined above). As it's represented as an object, it will also be able to hold extra fields. We'll use that functionality to add a reference to the winner of the game, if the game ends in a win. 
+The `result` field is updated after every move. This field will contain the status of the game (as we defined above). As it's represented as an object, it will also be able to hold extra fields. We'll use that functionality to add a reference to the winner of the game, if the game ends in a win.
 
 ## Accepting connections
 
-When a player connects via WebSocket, Sockets.IO will fire a [`connection`](https://socket.io/docs/v4/server-instance/#connection) event. We can listen for this event and handle tracking the connection, as well as creating listeners for other custom events. There are a few [custom events](https://socket.io/docs/v4/emitting-events/) we can define here, that our players will emit: 
+When a player connects via WebSocket, Sockets.IO will fire a [`connection`](https://socket.io/docs/v4/server-instance/#connection) event. We can listen for this event and handle tracking the connection, as well as creating listeners for other custom events. There are a few [custom events](https://socket.io/docs/v4/emitting-events/) we can define here, that our players will emit:
 
-- `addPlayer`: We'll use this event for a player to request joining the game. 
-- `action`: This is used when a player wants to make a move. 
-- `rematch`: Used when a game is over, but the players want to play again. 
+- `addPlayer`: We'll use this event for a player to request joining the game.
+- `action`: This is used when a player wants to make a move.
+- `rematch`: Used when a game is over, but the players want to play again.
 
-We can also listen for the built-in [`disconnect`](https://socket.io/docs/v4/server-socket-instance/#disconnect) event, which will alert us if a player leaves the game (for example, by closing the browser window or if their internet connection is lost). 
+We can also listen for the built-in [`disconnect`](https://socket.io/docs/v4/server-socket-instance/#disconnect) event, which will alert us if a player leaves the game (for example, by closing the browser window or if their internet connection is lost).
 
 Let's add the code that will hook up our listeners to the events:
 
 ```js
 io.on('connection', function (connection) {
-  connection.on('addPlayer', addPlayer(connection.id)); 
-  connection.on('action', action(connection.id)); 
+  connection.on('addPlayer', addPlayer(connection.id));
+  connection.on('action', action(connection.id));
   connection.on('rematch', rematch(connection.id));
-  connection.on('disconnect', disconnect(connection.id)); 
-}); 
+  connection.on('disconnect', disconnect(connection.id));
+});
 ```
 
-Next we'll implement each of these listener functions, starting with `addPlayer`. 
+Next we'll implement each of these listener functions, starting with `addPlayer`.
 
 **Side Note:** Normally in examples for custom listeners, you'll see the handler code added immediately with an anonymous function, like this:
 
@@ -141,11 +141,11 @@ Next we'll implement each of these listener functions, starting with `addPlayer`
 io.on('connection', function (connection) {
   connection.on('addPlayer', (data)=> {
   	// some code here
-  }); 
+  });
 
    connection.on('action', (data)=> {
   	// some code here
-  }); 
+  });
 
   // etc ...
 });
@@ -153,12 +153,12 @@ io.on('connection', function (connection) {
 
 This is convenient, especially when there are a couple of handlers, each with only a small amount of code. It's also handy because in each of the handler functions, you still have access to the `connection` object, which is not passed on each event. However, it can get a little messy and unwieldy if there are many event handlers, with more complex logic in each.
 
-We're doing it differently so that we can separate the handlers into functions elsewhere in the code base. We do have one problem to solve though: if they are separate functions, how will they access the `connection` parameter in such a way that we can tell which player sent the command? With the concept of [_closures_](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Closures), which are well-supported in Javascript, we can make functions that return another function. In this way, we can pass in the `connection.id` parameter to the first wrapping function, and it can return another function that takes the data arguments from the Socket.IO event caller. Because the second function is within the _closure_ of the first, it will have access to the `connection.id` parameter. The pattern looks like this: 
+We're doing it differently so that we can separate the handlers into functions elsewhere in the code base. We do have one problem to solve though: if they are separate functions, how will they access the `connection` parameter in such a way that we can tell which player sent the command? With the concept of [_closures_](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Closures), which are well-supported in Javascript, we can make functions that return another function. In this way, we can pass in the `connection.id` parameter to the first wrapping function, and it can return another function that takes the data arguments from the Socket.IO event caller. Because the second function is within the _closure_ of the first, it will have access to the `connection.id` parameter. The pattern looks like this:
 
 ```js
 io.on('connection', function (connection) {
-  connection.on('addPlayer', addPlayer(connection.id)); 
-  connection.on('action', action(connection.id)) ; 
+  connection.on('addPlayer', addPlayer(connection.id));
+  connection.on('action', action(connection.id)) ;
   // etc ...
 });
 
@@ -179,81 +179,81 @@ function action(socketId){
 
 ## Handling new players
 
-Add the following function to handle adding players: 
+Add the following function to handle adding players:
 
 ```js
 function addPlayer(socketId){
   return (data)=>{
-    const numberOfPlayers = gameState.players.length; 
+    const numberOfPlayers = gameState.players.length;
     if (numberOfPlayers >= 2){
-      return; 
-    } 
-      
-    let nextSymbol = 'X'; 
+      return;
+    }
+
+    let nextSymbol = 'X';
     if (numberOfPlayers === 1){
       if (gameState.players[0].symbol === 'X'){
-        nextSymbol = 'O'; 
+        nextSymbol = 'O';
       }
     }
 
     const newPlayer = {
-      playerName: data.playerName, 
-      id: socketId, 
+      playerName: data.playerName,
+      id: socketId,
       symbol: nextSymbol
-    }; 
+    };
 
-    gameState.players.push(newPlayer); 
+    gameState.players.push(newPlayer);
     if (gameState.players.length === 2){
       gameState.result.status = Statuses.PLAYING;
-      gameState.currentPlayer = newPlayer; 
+      gameState.currentPlayer = newPlayer;
     }
-    io.emit('gameState', gameState); 
-    
+    io.emit('gameState', gameState);
+
   }
 }
 ```
-This function does quite a bit. Let's go through the main features. 
+This function does quite a bit. Let's go through the main features.
 
-- First it checks to see how many players are already in the game. If there are already 2 players, it returns early without changing anything. If this check passes, it goes on to add a new player. Note that even when there is no space in the game for a new player, we don't disconnect the player - they still get updates and can watch the match. 
+- First it checks to see how many players are already in the game. If there are already 2 players, it returns early without changing anything. If this check passes, it goes on to add a new player. Note that even when there is no space in the game for a new player, we don't disconnect the player - they still get updates and can watch the match.
 - Next, the function figures out which symbol, _X_ or _O_, the new player should be. It will assign _X_ to the first player. If there is already a player, and the existing player's symbol is _X_, then it will assign _O_ to the new player. Note that there is a possible case where there is only one player, and their symbol is _O_. This would occur if there are 2 players, and the player with the _X_ symbol disconnects from the game, leaving only the player with the _O_ symbol. This is why we always check what symbol the existing player in the game has.
-- Then the function constructs a new player object with some identifying information, including the name that the player sends through, the `socketId` they connected on, and their symbol. When a new player requests to join, we expect them to send an object with a field `playerName` to tell us their handle. 
-- Now we add the new player to the player array in our `gameState` object, so that they are part of the game. 
-- We go on to check if we have 2 players, and start playing if we do. We begin by updating the status of the game to `PLAYING`, and set the `currentPlayer`, i.e. the player who is first to go, as the latest player to have joined. 
+- Then the function constructs a new player object with some identifying information, including the name that the player sends through, the `socketId` they connected on, and their symbol. When a new player requests to join, we expect them to send an object with a field `playerName` to tell us their handle.
+- Now we add the new player to the player array in our `gameState` object, so that they are part of the game.
+- We go on to check if we have 2 players, and start playing if we do. We begin by updating the status of the game to `PLAYING`, and set the `currentPlayer`, i.e. the player who is first to go, as the latest player to have joined.
 - Finally, we use the Socket.IO [`emit`](https://socket.io/docs/v4/emitting-events/) function to send the updated `gameState` to all connections. This will allow them to update the players' displays.
 
 ## Handling player actions
 
-The next handler takes care of the moves players make. We expect that the incoming data from the player will have a property called `gridIndex` to indicate which block on the board the player wants to mark. This should be a number that maps to the numbers for each block in the board, as in the picture earlier on. 
+The next handler takes care of the moves players make. We expect that the incoming data from the player will have a property called `gridIndex` to indicate which block on the board the player wants to mark. This should be a number that maps to the numbers for each block in the board, as in the picture earlier on.
 
 ```js
 function action(socketId){
   return (data)=> {
     if (gameState.result.status === Statuses.PLAYING && gameState.currentPlayer.id === socketId){
-      const player = gameState.players.find(p => p.id === socketId); 
+      const player = gameState.players.find(p => p.id === socketId);
       if (gameState.board[data.gridIndex] == null){
-        gameState.board[data.gridIndex] = player; 
-        gameState.currentPlayer = gameState.players.find(p => p !== player);  
+        gameState.board[data.gridIndex] = player;
+        gameState.currentPlayer = gameState.players.find(p => p !== player);
         checkForEndOfGame();
       }
     }
-    io.emit('gameState', gameState); 
+    io.emit('gameState', gameState);
   }
 }
 ```
 
-In this function, we check a couple of things first: 
-- The game status must be `PLAYING` - players can't make moves if the game is in any other state. 
-- The player attempting to make the move must be the `currentPlayer`, i.e. the player whose turn it is to go. 
+In this function, we check a couple of things first:
+- The game status must be `PLAYING` - players can't make moves if the game is in any other state.
+- The player attempting to make the move must be the `currentPlayer`, i.e. the player whose turn it is to go.
 
-If these conditions are met, we find the player in the `gameState.players` array using the built-in [`find`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find) method on arrays, by looking for the player by their `socketId`. 
+If these conditions are met, we find the player in the `gameState.players` array using the built-in [`find`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find) method on arrays, by looking for the player by their `socketId`.
 
 Now we can check if the board position (`gridIndex`) requested by the player is available. We check that the value for that position in the `gameState.board` array is `null`, and if it is, we assign the player to it.
 
-The player has made a successful move, so we give the other player a turn. We switch the `gameState.currentPlayer` to the other player by using the array [`find`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find) method again, to get the player who _does not_ match the current player. 
+The player has made a successful move, so we give the other player a turn. We switch the `gameState.currentPlayer` to the other player by using the array [`find`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find) method again, to get the player who _does not_ match the current player.
 
-We also need to check if the move the player made changed the status of the game. Did that move make them win the game, or is it a draw, or is the game still in play? We call out to a function `checkForEndOfGame` to check for this. We'll implement this function a little later, after we're done with all the handlers. 
+We also need to check if the move the player made changed the status of the game. Did that move make them win the game, or is it a draw, or is the game still in play? We call out to a function `checkForEndOfGame` to check for this. We'll implement this function a little later, after we're done with all the handlers.
 
-Finally, we send out the latest `gameState` to all the players (and spectators) to update the game UI. 
+Finally, we send out the latest `gameState` to all the players (and spectators) to update the game UI.
 
 ## Handling a rematch request
 
@@ -264,83 +264,83 @@ function rematch(socketId){
   return (data) => {
     if (gameState.players.findIndex(p=> p.id === socketId) < 0) return; // Don't let spectators rematch
     if (gameState.result.status === Statuses.WIN || gameState.result.status === Statuses.DRAW){
-      resetGame(); 
-      io.emit('gameState', gameState); 
+      resetGame();
+      io.emit('gameState', gameState);
     }
   }
 }
 ```
 
-This function first checks if the connection sending the rematch request is actually one of the players, and not just a spectator. If we can't find a match for a player, we return immediately, making no changes. 
+This function first checks if the connection sending the rematch request is actually one of the players, and not just a spectator. If we can't find a match for a player, we return immediately, making no changes.
 
-Then we check if the game is in one of the final states, either `WIN` or `DRAW`. If it is, we call out to a function `resetGame` to set up the game again. Finally, we send out the latest `gameState` to all the players. 
+Then we check if the game is in one of the final states, either `WIN` or `DRAW`. If it is, we call out to a function `resetGame` to set up the game again. Finally, we send out the latest `gameState` to all the players.
 
 Let's implement the `resetGame` function:
 
 ```js
 function resetGame(){
-  gameState.board = new Array(9).fill(null); 
+  gameState.board = new Array(9).fill(null);
 
   if (gameState.players.length === 2){
-    gameState.result.status = Statuses.PLAYING; 
-    const randPlayer = Math.floor(Math.random() * gameState.players.length); 
-    gameState.currentPlayer = gameState.players[randPlayer]; 
+    gameState.result.status = Statuses.PLAYING;
+    const randPlayer = Math.floor(Math.random() * gameState.players.length);
+    gameState.currentPlayer = gameState.players[randPlayer];
   } else {
     gameState.result.status = Statuses.WAITING;
-    gameState.currentPlayer = null;  
+    gameState.currentPlayer = null;
   }
 }
 ```
-Let's take a look at what we're doing here: 
+Let's take a look at what we're doing here:
 
-- First, our function creates a new array for the `gameState` board. This effectively clears the board, setting all the positions back to `null`, or empty. 
-- Then it checks that there are still 2 players connected. If there are, it sets the game status back to `PLAYING` and chooses at random which player's turn it is to go. We choose the first player randomly so that there isn't one player getting an advantage by going first every time. 
+- First, our function creates a new array for the `gameState` board. This effectively clears the board, setting all the positions back to `null`, or empty.
+- Then it checks that there are still 2 players connected. If there are, it sets the game status back to `PLAYING` and chooses at random which player's turn it is to go. We choose the first player randomly so that there isn't one player getting an advantage by going first every time.
 
-If there is only one player remaining, we set the game status to `WAITING` instead, and listen for any new players who want to join. We also set the `currentPlayer` to null, as we will choose which player should go once the new player has joined. 
+If there is only one player remaining, we set the game status to `WAITING` instead, and listen for any new players who want to join. We also set the `currentPlayer` to null, as we will choose which player should go once the new player has joined.
 
 ## Handling disconnects
 
-The last handler we need to implement is if a connection to a player is lost. This could be because the player has exited the game (by closing the browser tab), or has other internet issues. 
+The last handler we need to implement is if a connection to a player is lost. This could be because the player has exited the game (by closing the browser tab), or has other internet issues.
 
 ```js
 function disconnect(socketId){
   return (reason) => {
     gameState.players = gameState.players.filter(p => p.id != socketId);
     if (gameState.players !== 2){
-      resetGame(); 
-      io.emit('gameState', gameState); 
+      resetGame();
+      io.emit('gameState', gameState);
     }
   }
 }
 ```
-This function uses the built-in array [`filter`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter) function to remove the player that disconnected from the server. Since it's possible that the disconnect event isn't from a player but from a spectator, we check the number of players left after filtering the disconnecting socket from the player list. If there aren't 2 players remaining after filtering, we reset the game and send out the updated game state. 
+This function uses the built-in array [`filter`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter) function to remove the player that disconnected from the server. Since it's possible that the disconnect event isn't from a player but from a spectator, we check the number of players left after filtering the disconnecting socket from the player list. If there aren't 2 players remaining after filtering, we reset the game and send out the updated game state.
 
 ## Checking for the end of the game
 
-Now we can get back to implementing the `checkForEndOfGame()` function we referenced in the `action` handler. 
+Now we can get back to implementing the `checkForEndOfGame()` function we referenced in the `action` handler.
 
-We're only interested in detecting 2 cases: A win or a draw. 
+We're only interested in detecting 2 cases: A win or a draw.
 
-There are just 8 patterns that determine if a player has won at tic-tac-toe. Let's map them to our board with its indexed blocks: 
+There are just 8 patterns that determine if a player has won at tic-tac-toe. Let's map them to our board with its indexed blocks:
 
-![All possible win lines](/images/tutorials/27-tictactoe-kaboom/allwins.png) 
+![All possible win lines](/images/tutorials/27-tictactoe-kaboom/allwins.png)
 
 We can encode each of these winning patterns into an array of 3 numbers each. Then we can add each of those patterns to a larger array, like this:
 
 ```js
 const winPatterns = [
   [0, 1, 2],
-  [3, 4, 5], 
-  [6, 7, 8], 
-  [0, 3, 6], 
-  [1, 4, 7], 
+  [3, 4, 5],
+  [6, 7, 8],
+  [0, 3, 6],
+  [1, 4, 7],
   [2, 5, 8],
-  [0, 4, 8], 
-  [2, 4, 6] 
+  [0, 4, 8],
+  [2, 4, 6]
 ]
 ```
 
-Now that we have each winning pattern in an array, we can loop through each of them to see if there is a player that has positions that match any of the patterns. 
+Now that we have each winning pattern in an array, we can loop through each of them to see if there is a player that has positions that match any of the patterns.
 
 Since the players are also in an array in `gameState.players`, we can loop through that array, and check each player against the winning pattern array. If a player matches any of these patterns, we can change the game status to `WIN` and set that player as the winner in the results.
 
@@ -355,7 +355,7 @@ function checkForEndOfGame(){
       if (gameState.board[seq[0]] == player
           && gameState.board[seq[1]] == player
           && gameState.board[seq[2]] == player){
-            gameState.result.status = Statuses.WIN; 
+            gameState.result.status = Statuses.WIN;
             gameState.result.winner = player;
          }
     });
@@ -363,17 +363,17 @@ function checkForEndOfGame(){
 
   // Check for a draw
   if (gameState.result.status != Statuses.WIN){
-    const emptyBlock = gameState.board.indexOf(null); 
+    const emptyBlock = gameState.board.indexOf(null);
     if (emptyBlock == -1){
-      gameState.result.status = Statuses.DRAW; 
+      gameState.result.status = Statuses.DRAW;
     }
   }
 }
 ```
 
-We also check for a draw in this function. A draw is defined as when all the blocks are occupied (no more moves can be made), but no player has matched one of the win patterns. To check if there are no more empty blocks, we use the array method [`indexOf`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/indexOf) to find any `null` values in `gameState.board` array. Remember that `null` means an empty block here. The `indexOf` method will return `-1` if it can't find any `null` values. In that case, we set the game status to `DRAW`, ending the game. 
+We also check for a draw in this function. A draw is defined as when all the blocks are occupied (no more moves can be made), but no player has matched one of the win patterns. To check if there are no more empty blocks, we use the array method [`indexOf`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/indexOf) to find any `null` values in `gameState.board` array. Remember that `null` means an empty block here. The `indexOf` method will return `-1` if it can't find any `null` values. In that case, we set the game status to `DRAW`, ending the game.
 
-Now we have all the functionality we need on the server, let's move on to building the Kaboom website the players will use to play the game. 
+Now we have all the functionality we need on the server, let's move on to building the Kaboom website the players will use to play the game.
 
 ## Setting up Kaboom
 
@@ -395,18 +395,18 @@ This creates a new Kaboom canvas with a black background.
 
 Now we can add a reference to Socket.IO. Normally, in a plain HTML project, we could add a [`<script>`](https://www.w3schools.com/tags/tag_script.asp) tag and reference the Socket.IO [client script](https://socket.io/docs/v4/client-installation/#Installation), hosted automatically on our game server. However, here we will add the script programmatically. We can do this by accessing the [`document`](https://developer.mozilla.org/en-US/docs/Web/API/Document) object available in every browser, and insert a new element with our script. Add the following code to the `main.js` file below the code to initialise Kaboom.
 
-```js 
-let script = document.createElement("script");  
+```js
+let script = document.createElement("script");
 script.src = 'https://tic-tac-toe-server.<YOUR_USER_NAME>.repl.co' + '/socket.io/socket.io.js'
 document.head.appendChild(script);
 ```
-Replace the `<YOUR_USER_NAME>` part of the URL with your Replit username. This code inserts the new `<script>` tag into the [`<head>`](https://www.w3schools.com/tags/tag_head.asp) section of the underlying HTML page that Kaboom runs in. 
+Replace the `<YOUR_USER_NAME>` part of the URL with your Replit username. This code inserts the new `<script>` tag into the [`<head>`](https://www.w3schools.com/tags/tag_head.asp) section of the underlying HTML page that Kaboom runs in.
 
 Let's move on to creating the relevant scenes for our game. Kaboom ["scenes"](https://kaboomjs.com/#scene) allow us to group logic and levels together. In this game we'll have 2 scenes:
 - A "startGame" scene that will prompt for the player's name.
 - A "main" scene, which will contain all the logic to play the tic-tac-toe game.
 
-Let's move on to the code to prompt the player to enter their name. 
+Let's move on to the code to prompt the player to enter their name.
 
 ```js
 scene("startGame", () => {
@@ -438,19 +438,19 @@ scene("startGame", () => {
 go("startGame");
 ```
 
-To keep the calculations for the UI layout simpler, we'll use a fixed size for the screen. That's where the 2 constants for the screen width and height come in. 
+To keep the calculations for the UI layout simpler, we'll use a fixed size for the screen. That's where the 2 constants for the screen width and height come in.
 
-We use the Kaboom [`add`](https://kaboomjs.com/doc#add) function to display the prompt "What's your name?" on the screen, using the  [`text`](https://kaboomjs.com/doc#text) component. We choose a position halfway across the screen, `SCREEN_WIDTH / 2`, and about a third of the way down the screen, `SCREEN_HEIGHT / 3`. We add the [`origin`](https://kaboomjs.com/doc#origin) component, set to `center`, to indicate that the positions we set must be in the center of the text field. 
+We use the Kaboom [`add`](https://kaboomjs.com/doc#add) function to display the prompt "What's your name?" on the screen, using the  [`text`](https://kaboomjs.com/doc#text) component. We choose a position halfway across the screen, `SCREEN_WIDTH / 2`, and about a third of the way down the screen, `SCREEN_HEIGHT / 3`. We add the [`origin`](https://kaboomjs.com/doc#origin) component, set to `center`, to indicate that the positions we set must be in the center of the text field.
 
 Then we add another object with an empty `""` text component. This will display the characters the player types in. We position it exactly halfway down and across the screen. We also hold a reference to the object in the constant `nameField`.
 
-To get the user's keyboard input, we use the Kaboom function [`charInput`](https://kaboomjs.com/doc#charInput). This function calls an event handler each time a key on the keyboard is pressed. We take that character and append it to the text in the `nameField` object. Now, when a player presses a key to enter their name, it will show up on the screen. 
+To get the user's keyboard input, we use the Kaboom function [`charInput`](https://kaboomjs.com/doc#charInput). This function calls an event handler each time a key on the keyboard is pressed. We take that character and append it to the text in the `nameField` object. Now, when a player presses a key to enter their name, it will show up on the screen.
 
 Finally, we use the Kaboom function [`keyRelease`](https://kaboomjs.com/doc#keyRelease) to listen for when the player pushes the `enter` key. We'll take that as meaning they have finished entering their name and want to start the game. In the handler, we use the Kaboom [`go`](https://kaboomjs.com/doc#go) function to redirect to the main scene of the game.
 
-## Adding the game board 
+## Adding the game board
 
-Now we can add the UI elements for the game itself. Create the "main" scene in your Kaboom repl by adding the following code to draw the tic-tac-toe board: 
+Now we can add the UI elements for the game itself. Create the "main" scene in your Kaboom repl by adding the following code to draw the tic-tac-toe board:
 
 ```js
  scene("main", ({ playerName }) => {
@@ -475,56 +475,56 @@ Now we can add the UI elements for the game itself. Create the "main" scene in y
     rect(400, 1),
     pos(100, 366),
   ]);
-  
+
 });
 ```
 
-This adds 4 rectangles with a width of 1 pixel and length of 400 pixels to the screen - each rectangle is more like a line. This is how we draw the lines that create the classic tic-tac-toe board shape. The first 2 rectangles are the vertical lines, and the second 2 are the horizontal lines. We place the board closer to the left side of the screen, instead of the center, to save space for game information to be displayed on the right hand side of the screen. 
+This adds 4 rectangles with a width of 1 pixel and length of 400 pixels to the screen - each rectangle is more like a line. This is how we draw the lines that create the classic tic-tac-toe board shape. The first 2 rectangles are the vertical lines, and the second 2 are the horizontal lines. We place the board closer to the left side of the screen, instead of the center, to save space for game information to be displayed on the right hand side of the screen.
 
 If you run the game, and enter your name, you should see the board layout like this:
 
 ![board layout](/images/tutorials/27-tictactoe-kaboom/boardLayout.png)
 
-Now we need to add a way to draw the _X_ and _O_ symbols in each block. To do this, we'll add objects with text components in each block of the board. First, we'll make an array containing the location and size of each block. Add the following code snippets within the "main" scene we created above: 
+Now we need to add a way to draw the _X_ and _O_ symbols in each block. To do this, we'll add objects with text components in each block of the board. First, we'll make an array containing the location and size of each block. Add the following code snippets within the "main" scene we created above:
 
 ```js
 const boardSquares = [
-  {index: 0, x: 100, y: 100, width:133, height: 133 }, 
-  {index: 1, x: 233, y: 100, width:133, height: 133 }, 
-  {index: 2, x: 366, y: 100, width:133, height: 133 }, 
-  {index: 3, x: 100, y: 233, width:133, height: 133 }, 
-  {index: 4, x: 233, y: 233, width:133, height: 133 }, 
-  {index: 5, x: 366, y: 233, width:133, height: 133 }, 
-  {index: 6, x: 100, y: 366, width:133, height: 133 }, 
-  {index: 7, x: 233, y: 366, width:133, height: 133 }, 
+  {index: 0, x: 100, y: 100, width:133, height: 133 },
+  {index: 1, x: 233, y: 100, width:133, height: 133 },
+  {index: 2, x: 366, y: 100, width:133, height: 133 },
+  {index: 3, x: 100, y: 233, width:133, height: 133 },
+  {index: 4, x: 233, y: 233, width:133, height: 133 },
+  {index: 5, x: 366, y: 233, width:133, height: 133 },
+  {index: 6, x: 100, y: 366, width:133, height: 133 },
+  {index: 7, x: 233, y: 366, width:133, height: 133 },
   {index: 8, x: 366, y: 366, width:133, height: 133 }
 ];
 ```
 
-We can run through this array and create a text object that we can write to when we want to update the symbols on the board. Let's create a function to do that. 
+We can run through this array and create a text object that we can write to when we want to update the symbols on the board. Let's create a function to do that.
 
 ```js
 function createTextBoxesForGrid(){
   boardSquares.forEach((square)=>{
-    let x = square.x + square.width*0.5; 
-    let y = square.y + square.height*0.5; 
+    let x = square.x + square.width*0.5;
+    let y = square.y + square.height*0.5;
     square.textBox = add([
-      text('', 40), 
-      pos(x, y), 
+      text('', 40),
+      pos(x, y),
       origin('center')
     ]);
   })
 }
 
-createTextBoxesForGrid();     
+createTextBoxesForGrid();
 ```
-This function uses the array [`forEach`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach) method to loop through each "square" definition in the `boardSquares` array. We then find the center `x` and `y` of the square, and [`add`](https://kaboomjs.com/doc#add) a new text object to the screen, and also add it to the square definition on the field `textBox` so we can access it later to update it. We use the `origin` component to ensure the text is centered in the square. 
+This function uses the array [`forEach`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach) method to loop through each "square" definition in the `boardSquares` array. We then find the center `x` and `y` of the square, and [`add`](https://kaboomjs.com/doc#add) a new text object to the screen, and also add it to the square definition on the field `textBox` so we can access it later to update it. We use the `origin` component to ensure the text is centered in the square.
 
-Finally, we call the function to create the text boxes. 
+Finally, we call the function to create the text boxes.
 
 ## Adding player names and game status
 
-Now let's add some areas for the player's names and for the current status of the game (whose turn it is to play, if someone has won, or if it's a draw). 
+Now let's add some areas for the player's names and for the current status of the game (whose turn it is to play, if someone has won, or if it's a draw).
 
 ```js
 // Players and game status elements
@@ -544,7 +544,7 @@ const statusLabel = add([
   color(0, 255, 0)
 ])
 ```
-Here we add 3 objects with [`text`](https://kaboomjs.com/doc#text) components. The first 2 are placeholders for the player names and symbols. The third one is for the game status. They are positioned to the right of the screen, and contain empty text to start. We'll change the contents as we receive new game states from the server. The last object has a `color` component to set the color of the text to green. This is to make the status message stand out from the rest of the text.  
+Here we add 3 objects with [`text`](https://kaboomjs.com/doc#text) components. The first 2 are placeholders for the player names and symbols. The third one is for the game status. They are positioned to the right of the screen, and contain empty text to start. We'll change the contents as we receive new game states from the server. The last object has a `color` component to set the color of the text to green. This is to make the status message stand out from the rest of the text.
 
 
 ## Connecting to the server
@@ -553,76 +553,76 @@ To connect to the game server, we need to initialize the Socket.IO library we dy
 
 ![Copying server url](/images/tutorials/27-tictactoe-kaboom/server-url.png)
 
-Now add this code along with the server URL to the "main" scene in the player repl: 
+Now add this code along with the server URL to the "main" scene in the player repl:
 
 ```js
-var socket = io('https://tic-tac-toe-server.<YOUR_USER_NAME>.repl.co'); 
+var socket = io('https://tic-tac-toe-server.<YOUR_USER_NAME>.repl.co');
 
 socket.on('connect', function(){
   socket.emit("addPlayer", {
     playerName: playerName
   });
-}); 
+});
 ```
-In the first line, we initialize the [Socket.IO client library](https://socket.io/docs/v4/client-initialization/) to connect to the server. Then we add a listener to the [`connect`](https://socket.io/docs/v4/client-socket-instance/#Socket-connected) event. This lets us know when we have established a connection to the server. 
+In the first line, we initialize the [Socket.IO client library](https://socket.io/docs/v4/client-initialization/) to connect to the server. Then we add a listener to the [`connect`](https://socket.io/docs/v4/client-socket-instance/#Socket-connected) event. This lets us know when we have established a connection to the server.
 
-If we have a connection, we then [`emit`](https://socket.io/docs/v4/emitting-events/) an event to the server, with our custom event type `addPlayer`. We also add in the player name, which we passed to this scene from the `startGame` scene. Emitting the `addPlayer` event to the server will cause the `addPlayer` event handler to fire on the server side, adding the player to the game, and emitting back the game state. 
+If we have a connection, we then [`emit`](https://socket.io/docs/v4/emitting-events/) an event to the server, with our custom event type `addPlayer`. We also add in the player name, which we passed to this scene from the `startGame` scene. Emitting the `addPlayer` event to the server will cause the `addPlayer` event handler to fire on the server side, adding the player to the game, and emitting back the game state.
 
 ## Handling updated game state
 
-Remember that our server emits a `gameState` event whenever something changes in the game. We'll listen for that event, and update all the UI elements in an event handler. 
+Remember that our server emits a `gameState` event whenever something changes in the game. We'll listen for that event, and update all the UI elements in an event handler.
 
-First, we need to add the definitions of each status as we have done on the server side, so that we can easily reference them in the code: 
+First, we need to add the definitions of each status as we have done on the server side, so that we can easily reference them in the code:
 
 ```js
 const Statuses = {
-	WAITING: 'waiting', 
-	PLAYING: 'playing', 
-	DRAW: 'draw', 
+	WAITING: 'waiting',
+	PLAYING: 'playing',
+	DRAW: 'draw',
 	WIN: 'win'
 }
 ```
 
-Now we can add a listener and event handler: 
+Now we can add a listener and event handler:
 
 ```js
 socket.on('gameState', function(state){
   for (let index = 0; index < state.board.length; index++) {
     const player = state.board[index];
     if (player != null){
-      boardSquares[index].textBox.text = player.symbol; 
+      boardSquares[index].textBox.text = player.symbol;
     } else
     {
-      boardSquares[index].textBox.text = ''; 
+      boardSquares[index].textBox.text = '';
     }
   }
 
-  statusLabel.text = ''; 
+  statusLabel.text = '';
   switch (state.result.status) {
     case Statuses.WAITING:
-      statusLabel.text = 'Waiting for players....'; 
+      statusLabel.text = 'Waiting for players....';
       break;
     case Statuses.PLAYING:
-      statusLabel.text = state.currentPlayer.playerName + ' to play'; 
+      statusLabel.text = state.currentPlayer.playerName + ' to play';
     break;
     case Statuses.DRAW:
-      statusLabel.text = 'Draw! \nPress R for rematch'; 
+      statusLabel.text = 'Draw! \nPress R for rematch';
     break;
     case Statuses.WIN:
-      statusLabel.text = state.result.winner.playerName + ' Wins! \nPress R for rematch'; 
-    break;          
+      statusLabel.text = state.result.winner.playerName + ' Wins! \nPress R for rematch';
+    break;
     default:
       break;
   }
-  
-  playerOneLabel.text = ''; 
-  playerTwoLabel.text = ''; 
+
+  playerOneLabel.text = '';
+  playerTwoLabel.text = '';
   if (state.players.length > 0){
-    playerOneLabel.text = state.players[0].symbol + ': ' + state.players[0].playerName; 
+    playerOneLabel.text = state.players[0].symbol + ': ' + state.players[0].playerName;
   }
 
   if (state.players.length > 1){
-    playerTwoLabel.text = state.players[1].symbol + ': ' + state.players[1].playerName; 
+    playerTwoLabel.text = state.players[1].symbol + ': ' + state.players[1].playerName;
   }
 
 });
@@ -634,7 +634,7 @@ First, we loop through the board positions array that is passed from the server 
 
 Then we update the `statusLabel` to show what is currently happening in the game. We use a [`switch`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/switch) statement to create logic for each of the possibilities. We write a different message to the `statusLabel` text box depending on the status, drawing from data in the `gameState` object.
 
-Next we update the player name text boxes. First we reset them, in case one of the players has dropped out. Then we update the text boxes with the players' symbols and names. Note that we first check if there are the corresponding players in the array. 
+Next we update the player name text boxes. First we reset them, in case one of the players has dropped out. Then we update the text boxes with the players' symbols and names. Note that we first check if there are the corresponding players in the array.
 
 Now that we're done with updating from the game state, let's try running the game again. Open the game window in a new tab so that requests to the repl server don't get blocked by the browser due to the CORS header 'Access-Control-Allow-Origin' not matching in the embedded window.
 
@@ -644,33 +644,33 @@ Make sure the server is also running, and enter your name. You should see someth
 
 ![Waiting for another player](/images/tutorials/27-tictactoe-kaboom/waiting.png)
 
-You can connect to your game in another browser tab, and enter another name. Then you should see both names come up, and the status message change to allow a player to make a move. Of course, we haven't yet implemented the code to enable making a move from the UI, so let's do that now. 
+You can connect to your game in another browser tab, and enter another name. Then you should see both names come up, and the status message change to allow a player to make a move. Of course, we haven't yet implemented the code to enable making a move from the UI, so let's do that now.
 
 ## Handling player moves
 
-We want a player to be able to click on a block to place their move. Kaboom has a function [`mouseRelease`](https://kaboomjs.com/doc#mouseRelease) that we can use to handle mouse click events. All we need then is the position the mouse cursor is at, and we can map that to one of the board positions using our `boardSquares` array to do the lookup. We'll use the Kaboom function [`mousePos`](https://kaboomjs.com/doc#mousePos) to get the coordinates of the mouse: 
+We want a player to be able to click on a block to place their move. Kaboom has a function [`onMouseRelease`](https://kaboomjs.com/doc#onMouseRelease) that we can use to handle mouse click events. All we need then is the position the mouse cursor is at, and we can map that to one of the board positions using our `boardSquares` array to do the lookup. We'll use the Kaboom function [`mousePos`](https://kaboomjs.com/doc#mousePos) to get the coordinates of the mouse:
 
 ```js
-mouseRelease(() => {
+onMouseRelease(() => {
   const mpos = mousePos();
-  // find the square we clicked on 
+  // find the square we clicked on
   for (let index = 0; index < boardSquares.length; index++) {
     const square = boardSquares[index];
-    if (mpos.x > square.x 
-        && mpos.x < square.x + square.width 
-        && mpos.y > square.y 
+    if (mpos.x > square.x
+        && mpos.x < square.x + square.width
+        && mpos.y > square.y
         && mpos.y < square.y + square.height){
           socket.emit("action", {
             gridIndex: square.index
-          }); 
-          break; 
-        } 
+          });
+          break;
+        }
   }
 });
 ```
-If we find a 'hit' on one of the board squares, we emit our `action` event. We pass the index of the square that was clicked on as the payload data. The server listens for this event, and runs the logic we added for the `action` event on the server side. If the action changes the game state, the server will send back the new game state, and the UI elements update. 
+If we find a 'hit' on one of the board squares, we emit our `action` event. We pass the index of the square that was clicked on as the payload data. The server listens for this event, and runs the logic we added for the `action` event on the server side. If the action changes the game state, the server will send back the new game state, and the UI elements update.
 
-The only other input we need to implement is to check if the player wants a rematch. To do that, we'll assign the `r` key as the rematch command. We can use the Kaboom function [`charInput`](https://kaboomjs.com/doc#charInput) to listen for key press events. We'll check if the key is `r`, or `R`, then emit the `rematch` event. We don't have any data to pass with that, so we'll just pass `null`. 
+The only other input we need to implement is to check if the player wants a rematch. To do that, we'll assign the `r` key as the rematch command. We can use the Kaboom function [`charInput`](https://kaboomjs.com/doc#charInput) to listen for key press events. We'll check if the key is `r`, or `R`, then emit the `rematch` event. We don't have any data to pass with that, so we'll just pass `null`.
 
 ```js
 charInput((ch) => {
@@ -680,13 +680,13 @@ charInput((ch) => {
 });
 ```
 
-Now you can run the game (and the server), and open the game in another tab, and you should be able to play tic-tac-toe against yourself! Send a link to the game to a friend, and see if they can join and play against you. 
+Now you can run the game (and the server), and open the game in another tab, and you should be able to play tic-tac-toe against yourself! Send a link to the game to a friend, and see if they can join and play against you.
 
-![playing tic tac toe](/images/tutorials/27-tictactoe-kaboom/playing.png) 
+![playing tic tac toe](/images/tutorials/27-tictactoe-kaboom/playing.png)
 
 ## Next Steps
 
-Now that you know the basics of creating a multiplayer online game, try your hand at making some different games, like checkers or chess or go. 
+Now that you know the basics of creating a multiplayer online game, try your hand at making some different games, like checkers or chess or go.
 
 Happy coding!
 

--- a/tutorials/32-build-mario-with-kaboom.md
+++ b/tutorials/32-build-mario-with-kaboom.md
@@ -1,6 +1,6 @@
 # Building a *Mario*-like side-scroller with Kaboom.js
 
-The *Mario* series is one of the most known and loved game series of all time. The first *Mario* game was released by Nintendo in the mid-80s, and people haven't stopped playing *Mario* since. 
+The *Mario* series is one of the most known and loved game series of all time. The first *Mario* game was released by Nintendo in the mid-80s, and people haven't stopped playing *Mario* since.
 
 Tons of games still use the basic side-scroller formula of *Mario*, so it's a good game to build to learn the basics of game making. We'll build it in the new [Kaboom](https://kaboomjs.com) game engine. Kaboom has many useful functions for building platform games, and we'll try to go through as many as we can in this tutorial.
 
@@ -8,14 +8,14 @@ Tons of games still use the basic side-scroller formula of *Mario*, so it's a go
 
 ## Designing the game
 
-We'd like to make a game that has the *Mario* essence. This means we need a few things: 
+We'd like to make a game that has the *Mario* essence. This means we need a few things:
 
 - The ability to jump and bump into reward boxes.
 - A big and small character type.
 - The ability to attack enemies by jumping on them.
-- The classic *Mario* scrolling and camera motion. 
+- The classic *Mario* scrolling and camera motion.
 
-For the graphics, we will use a [tile set from this creator](https://dotstudio.itch.io/super-mario-1-remade-assets). 
+For the graphics, we will use a [tile set from this creator](https://dotstudio.itch.io/super-mario-1-remade-assets).
 
 ## Creating a new project in Replit
 
@@ -23,7 +23,7 @@ Head over to [Replit](https://replit.com) and create a new repl. Choose **Kaboom
 
 ![New mario repl](/images/tutorials/32-mario-kaboom/new-repl.png)
 
-After the repl has booted up, you should see a `main.js` file under the "Code" section. This is where we'll start coding. It already has some code in it, but we'll replace that. 
+After the repl has booted up, you should see a `main.js` file under the "Code" section. This is where we'll start coding. It already has some code in it, but we'll replace that.
 
 Download [this archive of sprite and asset files](/tutorial-files/mario-kaboom/mario-resources.zip) that we'll need for the game, and unzip them on your computer. In the Kaboom editor, click the "Files" icon in the sidebar. Now drag and drop all the sprite and asset files into the "sprites" folder. Once they have uploaded, you can click on the "Kaboom" icon in the sidebar, and return to the "main" code file.
 
@@ -47,7 +47,7 @@ To start, we need to set up Kaboom with the screen size and colors we want for t
   });
 ```
 
-This creates a new Kaboom canvas with a nice *Mario* sky-blue background. We also set the size of the view to 320x240 pixels, which is a very low resolution for a modern game, but the right kind of pixelation for a *Mario*-type remake. We use `scale` to make the background twice the size on screen - you can increase this value if you have a monitor with very high resolution. Click the "Run" button, and you should see a lovely blue sky in the output window. 
+This creates a new Kaboom canvas with a nice *Mario* sky-blue background. We also set the size of the view to 320x240 pixels, which is a very low resolution for a modern game, but the right kind of pixelation for a *Mario*-type remake. We use `scale` to make the background twice the size on screen - you can increase this value if you have a monitor with very high resolution. Click the "Run" button, and you should see a lovely blue sky in the output window.
 
 ![blue sky](/images/tutorials/32-mario-kaboom/blue-sky.png)
 
@@ -71,7 +71,7 @@ loadSprite("cloud", "cloud.png");
 loadSprite("castle", "castle.png");
 ```
 
-The first line, [`loadRoot`](https://kaboomjs.com/#loadRoot), specifies which folder to load all the sprites and game elements from, so we don't have to keep typing it in for each sprite. Then each line loads a game sprite and gives it a name so that we can refer to it in code later. 
+The first line, [`loadRoot`](https://kaboomjs.com/#loadRoot), specifies which folder to load all the sprites and game elements from, so we don't have to keep typing it in for each sprite. Then each line loads a game sprite and gives it a name so that we can refer to it in code later.
 
 Notice that the `mario` and `enemies` sprites are loaded with the function [`loadAseprite`](https://kaboomjs.com/#loadAseprite), and have an extra parameter specifying a `.json` file. This extra file is in a file format made by [Aseprite](https://www.aseprite.org), which is a pixel art and animation app. If you open the `Mario.png` file, you'll see that it has many different images of Mario in different positions, which are frames of Mario animations. The `.json` file from Aseprite contains all the information needed to animate Mario in our game. Kaboom knows how to interpret this file, and we can pick which animation we want to run at any time by choosing one from the `frameTags` list in the `.json` file and using the [`.play()`](https://kaboomjs.com/#sprite) method on a sprite. We can also choose a particular frame to show at any time, using the sprite's [`.frame`](https://kaboomjs.com/#sprite) property, and specifying the frame number to use, starting from 0.
 
@@ -83,7 +83,7 @@ Let's add 2 levels to start. You can create and add as many levels as you want -
 
 Kaboom has a really cool way of defining levels. It allows us to draw a layout of the level using only text. Each letter or symbol in this text map can be mapped to a character in the Kaboom game. In Kaboom, characters are anything that makes up the game world, including floor, platforms, and so on, and not only the players and bots.
 
-Add the following to define the levels: 
+Add the following to define the levels:
 
 ```js
 const LEVELS = [
@@ -126,7 +126,7 @@ const LEVELS = [
 ];
 ```
 
-Now we can map each symbol and letter in the levels to a [character definition](https://kaboomjs.com/#addLevel): 
+Now we can map each symbol and letter in the levels to a [character definition](https://kaboomjs.com/#addLevel):
 
 ```js
 const levelConf = {
@@ -244,15 +244,15 @@ Next we have definitions for each of the symbols we used in the map. Each defini
 
 Kaboom also allows you to write your own custom components to create any property or behavior you like for a character. The components `patrol`, `mario`, `enemy`, and `bump` are all custom here. You'll notice that those custom components are commented out (`//`), as we'll need to create the implementations for them before we can use them. We'll do that later in this tutorial.
 
-## Adding a scene 
+## Adding a scene
 
-Kaboom ["scenes"](https://kaboomjs.com/#scene) allow us to group logic and levels together. In this game we'll have 2 scenes: 
-- A "start"  or intro scene, which waits for a player to press a button to start the game. We'll also return to this scene if the player dies, so they can start again.  
-- A main "game" scene, which will contain the game levels and all the logic to move Mario, and the logic for the enemies and rewards, etc. 
+Kaboom ["scenes"](https://kaboomjs.com/#scene) allow us to group logic and levels together. In this game we'll have 2 scenes:
+- A "start"  or intro scene, which waits for a player to press a button to start the game. We'll also return to this scene if the player dies, so they can start again.
+- A main "game" scene, which will contain the game levels and all the logic to move Mario, and the logic for the enemies and rewards, etc.
 
-We can use the [`go`](https://kaboomjs.com/#go) function to switch between scenes. 
+We can use the [`go`](https://kaboomjs.com/#go) function to switch between scenes.
 
-Let's add the "start" scene, and make the game go to that scene by default: 
+Let's add the "start" scene, and make the game go to that scene by default:
 
 ```js
 scene("start", () => {
@@ -264,7 +264,7 @@ scene("start", () => {
     color(255, 255, 255),
   ]);
 
-  keyRelease("enter", () => {
+  onKeyRelease("enter", () => {
     go("game");
   })
 });
@@ -272,15 +272,15 @@ scene("start", () => {
 go("start");
 ```
 
-We define the scene using the [`scene`](https://kaboomjs.com/#scene) function. This function takes a string as the scene name – we're calling the scene "start". We're using an inline function here, using [arrow function notation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions). You could also use the `function` keyword, if you'd like to specify a function in that way. 
+We define the scene using the [`scene`](https://kaboomjs.com/#scene) function. This function takes a string as the scene name – we're calling the scene "start". We're using an inline function here, using [arrow function notation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions). You could also use the `function` keyword, if you'd like to specify a function in that way.
 
 We also add some instruction text in the scene function, using the [`text`](https://kaboomjs.com/#text) component and setting the text's content and size. The [`pos`](https://kaboomjs.com/#pos) component sets the position of the text on the screen, and the [`origin`](https://kaboomjs.com/#origin) component specifies that the center of the text should be used to position it. Finally, we set the color of the text to white using the [`color`](https://kaboomjs.com/#color) component, which takes RGB (red, green, blue) values from 0-255.
 
-We also have a call to the function [`keyRelease`](https://kaboomjs.com/#keyRelease), which listens for the enter key being pressed. If the enter key is pressed, we `go` to the main game scene (which we'll add shortly!).
+We also have a call to the function [`onKeyRelease`](https://kaboomjs.com/#onKeyRelease), which listens for the enter key being pressed. If the enter key is pressed, we `go` to the main game scene (which we'll add shortly!).
 
-Finally, we use the [`go`](https://kaboomjs.com/#go) function to go to the start scene when the game starts up. 
+Finally, we use the [`go`](https://kaboomjs.com/#go) function to go to the start scene when the game starts up.
 
-After copying the code into your repl, press Command + S (Mac) or Control + S (Windows/Linux) to update the output window. You should see something like this: 
+After copying the code into your repl, press Command + S (Mac) or Control + S (Windows/Linux) to update the output window. You should see something like this:
 
 <img src="/images/tutorials/32-mario-kaboom/start-scene.png"
 alt="start game screen"
@@ -290,7 +290,7 @@ Note that if you push enter now to start the game, you'll get an error message. 
 
 ## Adding the main game scene
 
-Now let's get the game scene up and running. Add the code below: 
+Now let's get the game scene up and running. Add the code below:
 
 ```js
 scene("game", (levelNumber = 0) => {
@@ -344,49 +344,49 @@ You should also see the enemy character wobble its feet, like it's trying to wal
 
 ![static mario world](/images/tutorials/32-mario-kaboom/mario-world.gif)
 
-Ok, back to looking at the code we added and what it does. First, we define a new [`scene`](https://kaboomjs.com/#scene) like we did for the start scene. This time, we specify a parameter `levelNumber` that can be passed to the scene. We give this parameter a default value of `0`. This will be the first level in our `LEVELS` array - remember, arrays start at index 0, so 0 is level 1. This parameter will let us call the same scene again when we get to the end of the level, but with `1` as the parameter so that we can play the next level. You can specify any parameters you like or need when creating a scene, and you can pass values from one scene to another. This is very useful, for example if you want to pass the player score to an end game scene, or pass in player options from the start scene. 
+Ok, back to looking at the code we added and what it does. First, we define a new [`scene`](https://kaboomjs.com/#scene) like we did for the start scene. This time, we specify a parameter `levelNumber` that can be passed to the scene. We give this parameter a default value of `0`. This will be the first level in our `LEVELS` array - remember, arrays start at index 0, so 0 is level 1. This parameter will let us call the same scene again when we get to the end of the level, but with `1` as the parameter so that we can play the next level. You can specify any parameters you like or need when creating a scene, and you can pass values from one scene to another. This is very useful, for example if you want to pass the player score to an end game scene, or pass in player options from the start scene.
 
 Next, we define some [`layers`](https://kaboomjs.com/#layers). Layers allow us to have backgrounds that don't affect the game - we call that layer `bg`. We'll place all the main game objects (like our hero, his enemies, and any other objects he interacts with) on the `game` layer, and all the UI elements (like current score, health, etc.) on the `ui` level. We make `game` the default layer, so if we don't specify a layer component on a game object, it will be drawn on the `game` layer.
 
 In the next line of code, we initialize and create the level by calling the [`addLevel`](https://kaboomjs.com/#addLevel) function. Here we pass in the level from the `LEVELS` array, using the index from the `levelNumber` parameter we added to the scene. We also pass in the configuration for all the symbols in the level map that we assigned to the `levelConf` variable. At this point, the map and all the characters in it are drawn to the screen. Note that, because the map is much wider than the size we set in the settings for the Kaboom window, we only see part of the map. This is great, because it will allow us to show more of the map as Mario starts walking.
 
-Then we add a few elements to the background layer - clouds, hills and shrubberies. Note the use of the `layer` component on these elements. We do this so that they don't interact with our game objects - they just add some visual interest. You can add as many as you like - the original *Mario* has them in a repeating pattern across the whole level. 
+Then we add a few elements to the background layer - clouds, hills and shrubberies. Note the use of the `layer` component on these elements. We do this so that they don't interact with our game objects - they just add some visual interest. You can add as many as you like - the original *Mario* has them in a repeating pattern across the whole level.
 
-We also add some temporary text to the `ui` layer to let the player know which level they are on. Notice that we use the [`lifespan`](https://kaboomjs.com/#lifespan) component here to automatically fade out and remove the info text after 1 second. 
+We also add some temporary text to the `ui` layer to let the player know which level they are on. Notice that we use the [`lifespan`](https://kaboomjs.com/#lifespan) component here to automatically fade out and remove the info text after 1 second.
 
 Finally, we add Mario to the game! We could have added him by placing his symbol, `p`, on our level map definition. However, by adding him manually to the scene using [`level.spawn()`](https://kaboomjs.com/#spawn), we can get a reference to him. This will be useful later when we are dealing with collisions and other interactions. We also set the position we want the character to initially be placed at.
 
 ## Making Mario move
 
-The scene is all set up, so let's add in some interaction. The player will use the arrow keys to move Mario left and right, and the space bar to make him jump. We'll use the [`keyDown`](https://kaboomjs.com/#keyDown) function for moving left and right, as we want Mario to keep moving as long as the player holds down either key. Then we can use the [`keyPress`](https://kaboomjs.com/#keyPress) function to make Mario jump. The player will need to push the space key each time they want Mario to jump - it's always fun to smash buttons! Add the following code at the bottom of the game scene: 
+The scene is all set up, so let's add in some interaction. The player will use the arrow keys to move Mario left and right, and the space bar to make him jump. We'll use the [`onKeyDown`](https://kaboomjs.com/#onKeyDown) function for moving left and right, as we want Mario to keep moving as long as the player holds down either key. Then we can use the [`onKeyPress`](https://kaboomjs.com/#onKeyPress) function to make Mario jump. The player will need to push the space key each time they want Mario to jump - it's always fun to smash buttons! Add the following code at the bottom of the game scene:
 
 ```js
     const SPEED = 120;
 
-    keyDown("right", () => {
+    onKeyDown("right", () => {
       player.flipX(false);
       player.move(SPEED, 0);
     });
 
-    keyDown("left", () => {
+    onKeyDown("left", () => {
       player.flipX(true);
       if (toScreen(player.pos).x > 20) {
         player.move(-SPEED, 0);
       }
     });
 
-    keyPress("space", () => {
+    onKeyPress("space", () => {
       if (player.grounded()) {
         player.jump();
       }
     });
 ```
 
-Take a look at the`keyDown` handlers `"right"` and `"left"`. We use the `flipX` method that is added to the character through the [`sprite`](https://kaboomjs.com/#sprite) component. If this is `true`, it draws the sprite as a mirror image. This flip will make Mario face in the correct direction. We call the `move` method, which is added by the [`pos`](https://kaboomjs.com/#pos) component. Our `move` method takes in the number of pixels to move per second, which we set in the `SPEED` constant. You might want to move this constant definition nearer to the top of the file, so it's easier to find if you want to tweak it later. 
+Take a look at the`onKeyDown` handlers `"right"` and `"left"`. We use the `flipX` method that is added to the character through the [`sprite`](https://kaboomjs.com/#sprite) component. If this is `true`, it draws the sprite as a mirror image. This flip will make Mario face in the correct direction. We call the `move` method, which is added by the [`pos`](https://kaboomjs.com/#pos) component. Our `move` method takes in the number of pixels to move per second, which we set in the `SPEED` constant. You might want to move this constant definition nearer to the top of the file, so it's easier to find if you want to tweak it later.
 
-In the `"left"` handler, there is also another check. In *Mario*, you can't walk back to previous parts of a level once it's gone off screen. We can simulate this by checking if Mario is near the left edge of the screen. We get Mario's current position by calling the [`pos`](https://kaboomjs.com/#pos) method which is added by the `pos` component. However, this position will be relative to the whole level, and not just the onscreen view. To help us figure out if Mario is near the edge of the screen, and not just at the beginning of the level, we can use the [`toScreen`](https://kaboomjs.com/#toScreen) function, which converts "game world" or level co-ordinates to actual screen co-ordinates. 
+In the `"left"` handler, there is also another check. In *Mario*, you can't walk back to previous parts of a level once it's gone off screen. We can simulate this by checking if Mario is near the left edge of the screen. We get Mario's current position by calling the [`pos`](https://kaboomjs.com/#pos) method which is added by the `pos` component. However, this position will be relative to the whole level, and not just the onscreen view. To help us figure out if Mario is near the edge of the screen, and not just at the beginning of the level, we can use the [`toScreen`](https://kaboomjs.com/#toScreen) function, which converts "game world" or level co-ordinates to actual screen co-ordinates.
 
-When a player releases the space key, we want to make Mario jump. To do this, we can call the [`jump`](https://kaboomjs.com/#body) method, which is added to the character through the [`body`](https://kaboomjs.com/#body) component. However, `jump` will make the character shoot up, even if it is already in the air. To prevent this double jumping, we first check if the player is standing on some [`solid`](https://kaboomjs.com/#solid) object. The [`body`](https://kaboomjs.com/#body) component also adds the [`grounded()`](https://kaboomjs.com/#body) function, which returns `true` if the player is indeed standing on a solid object. 
+When a player releases the space key, we want to make Mario jump. To do this, we can call the [`jump`](https://kaboomjs.com/#body) method, which is added to the character through the [`body`](https://kaboomjs.com/#body) component. However, `jump` will make the character shoot up, even if it is already in the air. To prevent this double jumping, we first check if the player is standing on some [`solid`](https://kaboomjs.com/#solid) object. The [`body`](https://kaboomjs.com/#body) component also adds the [`grounded()`](https://kaboomjs.com/#body) function, which returns `true` if the player is indeed standing on a solid object.
 
 Press Command + S or Control + S to update the output, and test it out. Mario should move around, but it doesn't look very natural and *Mario*-like - yet! Another thing you'll notice is that the screen does not scroll when Mario walks to the right, so we can't get to the rest of the level. Let's fix that first.
 
@@ -394,12 +394,12 @@ Press Command + S or Control + S to update the output, and test it out. Mario sh
 
 ## Adding scrolling
 
-Kaboom has a number of functions to control the "camera" of the scene. The camera represents the field of view that the player can see. At the moment, the camera only shows the first part of the level. By using the [`camPos`](https://kaboomjs.com/#camPos) function, we can move the camera to show more of the level as Mario walks across the scene. 
+Kaboom has a number of functions to control the "camera" of the scene. The camera represents the field of view that the player can see. At the moment, the camera only shows the first part of the level. By using the [`camPos`](https://kaboomjs.com/#camPos) function, we can move the camera to show more of the level as Mario walks across the scene.
 
-Let's add this code to the game scene: 
+Let's add this code to the game scene:
 
 ```js
-player.action(() => {
+player.onUpdate(() => {
   // center camera to player
   var currCam = camPos();
   if (currCam.x < player.pos.x) {
@@ -408,9 +408,9 @@ player.action(() => {
 });
 ```
 
-Here we add a handler to the [`action`](https://kaboomjs.com/#action) event for the player. This is called for each frame that is rendered. In this handler, we get the camera's current position by calling the [`camPos`](https://kaboomjs.com/#camPos) function without any arguments. Then we can check if Mario is further to the right of the scene than the camera is. If he is, then we set the camera's X position to that of Mario, so essentially the camera is following Mario. We only do this if he is further to the right of the camera, and not for positions further to the left. This is because we don't want the player to be able to go back on a level. 
+Here we add a handler to the [`onUpdate`](https://kaboomjs.com/#onUpdate) event for the player. This is called for each frame that is rendered. In this handler, we get the camera's current position by calling the [`camPos`](https://kaboomjs.com/#camPos) function without any arguments. Then we can check if Mario is further to the right of the scene than the camera is. If he is, then we set the camera's X position to that of Mario, so essentially the camera is following Mario. We only do this if he is further to the right of the camera, and not for positions further to the left. This is because we don't want the player to be able to go back on a level.
 
-Update the output again and test it out. As you move Mario past the center of the screen, the camera should start following him, giving the sense of scrolling. 
+Update the output again and test it out. As you move Mario past the center of the screen, the camera should start following him, giving the sense of scrolling.
 
 ![Scrolling](/images/tutorials/32-mario-kaboom/scrolling.gif)
 
@@ -431,7 +431,7 @@ function customComponent(args) {
 }
 
 ```
-In the object we return, Kaboom requires an `id`, which is a unique name for the component. Kaboom also needs a `require` property, which is a list of other components this component needs in order to work. When a component is first initialized on a game object, Kaboom calls the `add()` method so we have the opportunity to run any setup code we need. The method `update()` is called on every game frame, so we can make animation and collision updates there. 
+In the object we return, Kaboom requires an `id`, which is a unique name for the component. Kaboom also needs a `require` property, which is a list of other components this component needs in order to work. When a component is first initialized on a game object, Kaboom calls the `add()` method so we have the opportunity to run any setup code we need. The method `update()` is called on every game frame, so we can make animation and collision updates there.
 
 One behavior we need is for the enemy characters to walk up and down, instead of just standing in one place. Let's make a custom component we can add to our enemy characters so that they automatically move back and forth, or patrol their part of the level. Add the code below to the bottom of `main.js`:
 
@@ -459,23 +459,23 @@ function patrol(distance = 100, speed = 50, dir = 1) {
 }
 ```
 
-We've called this custom component "patrol", as it will make a character move some `distance`, at a set `speed`, and then turn around and walk in the opposite direction, `dir`. The character will also turn and move in the opposite direction if it collides with another game object. Because we use the `move` method (which is part of the [`pos`](https://kaboomjs.com/#pos) component), and the `collide` event handler (which is part of the [`area`](https://kaboomjs.com/#area) component), we add the `pos` and `area` components to the `require` list. 
+We've called this custom component "patrol", as it will make a character move some `distance`, at a set `speed`, and then turn around and walk in the opposite direction, `dir`. The character will also turn and move in the opposite direction if it collides with another game object. Because we use the `move` method (which is part of the [`pos`](https://kaboomjs.com/#pos) component), and the `collide` event handler (which is part of the [`area`](https://kaboomjs.com/#area) component), we add the `pos` and `area` components to the `require` list.
 
-When the component is first initialized, we want to record its starting position. This is so that we know how far the character is from where it started off, and therefore we'll know when we must turn it to move in the opposite direction. We do this by making use of the `add()` method. As we mentioned above, Kaboom will call this method on our component when the character is added to the scene. We read the position of the character at that time by calling `this.pos`: `this` refers to our character (as our component is made part of the character, `this` is reference to the combination of all the components making up the character). We can save this initial position to a property of the component object, in our case one called `startingPos`. We then attach a [`collide`](https://kaboomjs.com/#area) handler, so we know if the character bumps into anything, so we can turn it and move it in the opposite direction again. 
+When the component is first initialized, we want to record its starting position. This is so that we know how far the character is from where it started off, and therefore we'll know when we must turn it to move in the opposite direction. We do this by making use of the `add()` method. As we mentioned above, Kaboom will call this method on our component when the character is added to the scene. We read the position of the character at that time by calling `this.pos`: `this` refers to our character (as our component is made part of the character, `this` is reference to the combination of all the components making up the character). We can save this initial position to a property of the component object, in our case one called `startingPos`. We then attach a [`collide`](https://kaboomjs.com/#area) handler, so we know if the character bumps into anything, so we can turn it and move it in the opposite direction again.
 
-The [`collide`](https://kaboomjs.com/#on) handler has 2 arguments passed to it: the `obj` that our character collided with, and the `side` of character that was hit. We only want to flip the direction our character moves in if it was hit from the sides `left` and `right`. To change the direction, we flip the sign of our `dir` variable, which we'll use in the `update()` method. 
+The [`collide`](https://kaboomjs.com/#on) handler has 2 arguments passed to it: the `obj` that our character collided with, and the `side` of character that was hit. We only want to flip the direction our character moves in if it was hit from the sides `left` and `right`. To change the direction, we flip the sign of our `dir` variable, which we'll use in the `update()` method.
 
 The `update()` method is called for each frame. In it, we first check if the character is further than the specified maximum `distance` from its starting position. If it is, we switch the sign of the `dir` variable to make the character move in the opposite direction. Note that we we use the [`Math.abs`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/abs) function, which returns the absolute value of a number. The absolute value of a number is always positive, and this allows us to compare it to our `distance` variable, which is also a positive value. Then we call the `move` method (provided by the [`pos`](https://kaboomjs.com/#pos) component) and use the `speed` variable (passed in when the component was created) along with the `dir` variable to specify how fast and in which direction to move the character for this frame.
 
-Now that we've created this component, let's use it on a character. Uncomment the lines `//patrol` wherever you see it in the `levelConf` setup we created. Update the output and test it out. You should see the enemy character walk back and forth. 
+Now that we've created this component, let's use it on a character. Uncomment the lines `//patrol` wherever you see it in the `levelConf` setup we created. Update the output and test it out. You should see the enemy character walk back and forth.
 
 ![Patrol component](/images/tutorials/32-mario-kaboom/patrol.gif)
 
-You'll notice we also make use of the `patrol` component on the `bigMushy` character, which we'll use to make Mario grow from small Mario to big Mario. We'll get to that in a bit. 
+You'll notice we also make use of the `patrol` component on the `bigMushy` character, which we'll use to make Mario grow from small Mario to big Mario. We'll get to that in a bit.
 
 ## Creating a custom component for the enemies
 
-Now that the enemies are moving around, we can give them some more behaviors and properties. One of the most important things to do is to squash the enemies if Mario jumps on them. If you take a look at the `enemies.png` sprite file, you'll see that the 3rd frame (index 2) is an image of the enemy, but squashed. 
+Now that the enemies are moving around, we can give them some more behaviors and properties. One of the most important things to do is to squash the enemies if Mario jumps on them. If you take a look at the `enemies.png` sprite file, you'll see that the 3rd frame (index 2) is an image of the enemy, but squashed.
 
 ![Enemies-index](/images/tutorials/32-mario-kaboom/enemies-index.png)
 
@@ -506,11 +506,11 @@ function enemy() {
 
 We define the custom component as we did before. Because we need to stop the enemy from patrolling, we require the `patrol` custom component. We also require the [`sprite`](https://kaboomjs.com/#sprite) component so we can stop the animation and set the squashed frame to display. The [`area`](https://kaboomjs.com/#area) component is necessary, as the squashed enemy frame is half the height of the regular enemy frames (8 pixels vs 16 pixels). We're going to need to adjust the height of the area so that the collision zone the enemy occupies once squashed is correct.
 
-As a side note, pressing F1 in the game turns on Kaboom debugging, which will draw the [`area`](https://kaboomjs.com/#area) box around each game element, so you can easily see when characters collide. It also shows other handy info, like the frame rate and character properties. 
+As a side note, pressing F1 in the game turns on Kaboom debugging, which will draw the [`area`](https://kaboomjs.com/#area) box around each game element, so you can easily see when characters collide. It also shows other handy info, like the frame rate and character properties.
 
 ![debug mode](/images/tutorials/32-mario-kaboom/debug-mode.png)
 
-Back to our code. We execute our enemy squash in the `squash` method. We have a flag called `isAlive`, which we'll use to determine if the enemy is able to hurt Mario. This is usually `true`, but set to `false` once the enemy is squashed and harmless. We also `unuse` the patrol component so that the enemy stops walking back and forth. Then we call `stop`, which is a method added by the [`sprite`](https://kaboomjs.com/#sprite) component. Calling `stop` stops playing the current animation. Then we set the `frame` of the sprite to use to `2`, which is the squashed enemy frame, and update the [`area`](https://kaboomjs.com/#area) width and height to be the same size as the frame. Finally, we call `use` to add the [`lifespan`](https://kaboomjs.com/#lifespan) component so that the character is removed from the scene after `0.5` seconds, and fades out for `0.1` seconds. 
+Back to our code. We execute our enemy squash in the `squash` method. We have a flag called `isAlive`, which we'll use to determine if the enemy is able to hurt Mario. This is usually `true`, but set to `false` once the enemy is squashed and harmless. We also `unuse` the patrol component so that the enemy stops walking back and forth. Then we call `stop`, which is a method added by the [`sprite`](https://kaboomjs.com/#sprite) component. Calling `stop` stops playing the current animation. Then we set the `frame` of the sprite to use to `2`, which is the squashed enemy frame, and update the [`area`](https://kaboomjs.com/#area) width and height to be the same size as the frame. Finally, we call `use` to add the [`lifespan`](https://kaboomjs.com/#lifespan) component so that the character is removed from the scene after `0.5` seconds, and fades out for `0.1` seconds.
 
 Now let's add this custom component to the enemy. First, uncomment the `//enemy(),` line in the `levelConf` setup we created earlier. Now create a collision handler in the game scene between Mario and the enemy, so we know when it gets squashed:
 
@@ -518,7 +518,7 @@ Now let's add this custom component to the enemy. First, uncomment the `//enemy(
 ```js
 let canSquash = false;
 
-player.collides("badGuy", (baddy) => {
+player.onCollide("badGuy", (baddy) => {
   if (baddy.isAlive == false) return;
   if (canSquash) {
     // Mario has jumped on the bad guy:
@@ -529,12 +529,12 @@ player.collides("badGuy", (baddy) => {
 });
 ```
 
-In this `collides` handler, we check if the player, Mario, collides with a `badGuy` - which is the tag we gave to the enemies in the `levelConf` setup above. Then we attach our handler, which takes the `baddy` character Mario collided with. We first check if the `baddy` is still alive - if not we leave early, as there is no real interaction between Mario and a dead enemy. Then, we check the `canSquash` variable - if it is set to `true`, that means Mario has jumped onto the enemy. In this case, we call the `squash` method, which we created in the custom component for the enemy. This will execute all the logic we added there, and "kill" the enemy. We leave a bit of room in the handler to come back and add logic if Mario collides with the enemy without jumping on it - we'll add in that logic later. 
+In this `onCollide` handler, we check if the player, Mario, collides with a `badGuy` - which is the tag we gave to the enemies in the `levelConf` setup above. Then we attach our handler, which takes the `baddy` character Mario collided with. We first check if the `baddy` is still alive - if not we leave early, as there is no real interaction between Mario and a dead enemy. Then, we check the `canSquash` variable - if it is set to `true`, that means Mario has jumped onto the enemy. In this case, we call the `squash` method, which we created in the custom component for the enemy. This will execute all the logic we added there, and "kill" the enemy. We leave a bit of room in the handler to come back and add logic if Mario collides with the enemy without jumping on it - we'll add in that logic later.
 
-Modify the `keyPress` handler for the  `space` key as follows:
+Modify the `onKeyPress` handler for the  `space` key as follows:
 
 ```javascript
-  keyPress("space", () => {
+  onKeyPress("space", () => {
     if (player.grounded()) {
       player.jump();
       canSquash = true;
@@ -544,7 +544,7 @@ Modify the `keyPress` handler for the  `space` key as follows:
 
 Here, we set the `canSquash` variable to `true` to allow the player to squash the enemy if the player has jumped over it upon collision.
 
-Add the following code to the `player.action` handler:
+Add the following code to the `player.onUpdate` handler:
 
 ```javascript
 if (player.grounded()) {
@@ -554,15 +554,15 @@ if (player.grounded()) {
 
 This code will reset the `canSquash` variable so that the player will not squash the enemy if it hasn't jumped over it in the collision handler we added earlier.
 
-Update the output and test our game out. If you jump on an enemy, it should be squashed and then disappear after half a second. 
+Update the output and test our game out. If you jump on an enemy, it should be squashed and then disappear after half a second.
 
 ![Squash enemy](/images/tutorials/32-mario-kaboom/squash.gif)
 
 ## Headbutting surprise boxes
 
-Another key *Mario* action is headbutting the surprise boxes (the ones with "?" on them). In *Mario World*, this could release a coin, a super mushroom (one that makes Mario grow bigger), etc. When Mario headbutts these boxes, the box is 'bumped' and moves up and down quickly, while releasing its surprise. Once the box is empty, the "?" is removed from it. Let's create the logic to control these boxes. As above, we'll make more use of custom components. 
+Another key *Mario* action is headbutting the surprise boxes (the ones with "?" on them). In *Mario World*, this could release a coin, a super mushroom (one that makes Mario grow bigger), etc. When Mario headbutts these boxes, the box is 'bumped' and moves up and down quickly, while releasing its surprise. Once the box is empty, the "?" is removed from it. Let's create the logic to control these boxes. As above, we'll make more use of custom components.
 
-We'll take care of the boxes for coins and for the grow-bigger mushrooms. If you take a look in the `levelConf` setup we added in the beginning, you'll see entries for coin and mushroom "question boxes". The only real difference between the two is the final tag, which marks which surprise the box should release. We also have definitions for an empty box (`!`), the coin (`c`), and the mushroom (`M`). 
+We'll take care of the boxes for coins and for the grow-bigger mushrooms. If you take a look in the `levelConf` setup we added in the beginning, you'll see entries for coin and mushroom "question boxes". The only real difference between the two is the final tag, which marks which surprise the box should release. We also have definitions for an empty box (`!`), the coin (`c`), and the mushroom (`M`).
 
 Let's create a component that makes the box jump up and fall back down when it is headbutted. We can also re-use it on the coin to make it flip as it's bumped out of the box. We'll call this new component `bump`:
 
@@ -597,21 +597,21 @@ Let's create a component that makes the box jump up and fall back down when it i
   }
 ```
 
-This looks a bit more complicated than our other custom components, but that's only because it has code for the object moving in both directions. First off, we have a few parameters when creating this component: 
+This looks a bit more complicated than our other custom components, but that's only because it has code for the object moving in both directions. First off, we have a few parameters when creating this component:
 
-- `offset` is how far up we want the object to be bumped before settling down again. 
+- `offset` is how far up we want the object to be bumped before settling down again.
 - `speed` is how fast we want it to move when bumped.
 - `stopAtOrigin` specifies whether we want the object to return to its original position after being bumped, or just keep falling down - if this parameter is `false`, then bumping the object will make it look like it got dislodged and it will fall down.
 
-The object this component is added to must also have the `pos` component. We'll use that to move the object when it is bumped. 
+The object this component is added to must also have the `pos` component. We'll use that to move the object when it is bumped.
 
-We add a method, `bump`, which we can call from a collision handler or elsewhere. This sets the property `bumped` to `true`. This is a flag in the `update` method that will trigger the bump behavior. In the `bump` method, we also record the `y` position of the object in a property `origPos` so that we can stop the object at its original position if the `stopAtOrigin` flag has been set. 
+We add a method, `bump`, which we can call from a collision handler or elsewhere. This sets the property `bumped` to `true`. This is a flag in the `update` method that will trigger the bump behavior. In the `bump` method, we also record the `y` position of the object in a property `origPos` so that we can stop the object at its original position if the `stopAtOrigin` flag has been set.
 
-In the `update` method, which is run on each frame, we first check if the `bumped` flag has been set. If it has, we update the `y` position of the object using the `speed` we set, and in the current `direction`. On a screen, the top of the screen is where y = 0, and the bottom is the max height of the screen. Therefore to start, `direction` is set to `-1` to move the object up. Then we have a check to see if the new position of the object is higher than the `offset` parameter distance from the object's original position. If it is, we reverse the direction, so the object now starts moving back down. 
+In the `update` method, which is run on each frame, we first check if the `bumped` flag has been set. If it has, we update the `y` position of the object using the `speed` we set, and in the current `direction`. On a screen, the top of the screen is where y = 0, and the bottom is the max height of the screen. Therefore to start, `direction` is set to `-1` to move the object up. Then we have a check to see if the new position of the object is higher than the `offset` parameter distance from the object's original position. If it is, we reverse the direction, so the object now starts moving back down.
 
-Next, we have a check to see if the flag `stopAtOrigin` is set. If the object has fallen down to its original position (or further), we set the `bumped` flag back to `false` and update the object's position exactly back to its original position. We also set the `direction` flag back to `-1`, so the object is back in a state that it can be bumped again. 
+Next, we have a check to see if the flag `stopAtOrigin` is set. If the object has fallen down to its original position (or further), we set the `bumped` flag back to `false` and update the object's position exactly back to its original position. We also set the `direction` flag back to `-1`, so the object is back in a state that it can be bumped again.
 
-Now that this `bump` component exists, you can uncomment the `//bump(),` lines in the `levelConf` setup we created earlier. 
+Now that this `bump` component exists, you can uncomment the `//bump(),` lines in the `levelConf` setup we created earlier.
 
 To trigger the bump and add the code to make the surprise come out, we'll need to add a collision handler. Believe it or not, Kaboom has a special case collision event called `headbutt`  (which is not documented, but you can also find it in the [source code](https://github.com/replit/kaboom)) just for this type of thing!
 
@@ -633,13 +633,13 @@ player.on("headbutt", (obj) => {
 });
 ```
 
-In the handler for `headbutt`, we are passed the object, `obj`, that the player headbutted. We check to see if it is indeed one of our `questionBox` objects. If it is, we check if it is a `coinBox` (a coin must pop out) or a `mushyBox` (a grow-bigger mushroom should pop out). 
+In the handler for `headbutt`, we are passed the object, `obj`, that the player headbutted. We check to see if it is indeed one of our `questionBox` objects. If it is, we check if it is a `coinBox` (a coin must pop out) or a `mushyBox` (a grow-bigger mushroom should pop out).
 
-If it is a `coinBox`, we `spawn` a new coin 1 block above the coin box, using the configuration `c` we setup for a coin in the `levelConf` in the beginning. Then we call `bump` on the coin to invoke our custom component's method to make it appear to flip up out of the box. 
+If it is a `coinBox`, we `spawn` a new coin 1 block above the coin box, using the configuration `c` we setup for a coin in the `levelConf` in the beginning. Then we call `bump` on the coin to invoke our custom component's method to make it appear to flip up out of the box.
 
-If it is a `mushyBox`, we do the same, except we don't bump the mushroom. The mushroom has our custom `patrol` component added to it (check in the `levelConf` for `M`), so it will start moving immediately. We set the patrol distance very large on the mushroom so it won't automatically turn around, it will just keep going until if falls of the screen. 
+If it is a `mushyBox`, we do the same, except we don't bump the mushroom. The mushroom has our custom `patrol` component added to it (check in the `levelConf` for `M`), so it will start moving immediately. We set the patrol distance very large on the mushroom so it won't automatically turn around, it will just keep going until if falls of the screen.
 
-Then, to replace the `questionBox` with an empty box, we first record its position, then [`destroy`](https://kaboomjs.com/#destroy) it, and `spawn` a new empty box (`!` in the `levelConf`) to take its place. Finally, we `bump` this new box to give it the motion we want. 
+Then, to replace the `questionBox` with an empty box, we first record its position, then [`destroy`](https://kaboomjs.com/#destroy) it, and `spawn` a new empty box (`!` in the `levelConf`) to take its place. Finally, we `bump` this new box to give it the motion we want.
 
 Cool, time to update the output and test this out. When you jump up using the `space` key and headbutt the question boxes now, they should move and have things pop out!
 
@@ -651,10 +651,10 @@ Now we've got the basics of all the other game elements down, it's time to creat
 
 - Make Mario get bigger or smaller.
 - Run the "running" animation when Mario is running, and change to a standing or jumping frame in other cases.
-- "Freeze" Mario when he gets to the castle or has died, so the player can no longer move him. 
+- "Freeze" Mario when he gets to the castle or has died, so the player can no longer move him.
 - Handle Mario dying, with a classic spring up and out of the scene.
 
-Ok, here it is, our Mario custom component: 
+Ok, here it is, our Mario custom component:
 
 ```js
 function mario() {
@@ -725,45 +725,45 @@ function mario() {
   }
 ```
 
-Firstly, we require the character to have a few other components: [`body`](https://kaboomjs.com/#body), so we can determine if Mario is jumping or on the ground; [`area`](https://kaboomjs.com/#area), so we can change the collision box area of Mario as he grows or shrinks; [`sprite`](https://kaboomjs.com/#sprite), so we can start and stop animations and set static frames; and our custom `bump` component, so we can throw Mario off the screen if he dies. 
+Firstly, we require the character to have a few other components: [`body`](https://kaboomjs.com/#body), so we can determine if Mario is jumping or on the ground; [`area`](https://kaboomjs.com/#area), so we can change the collision box area of Mario as he grows or shrinks; [`sprite`](https://kaboomjs.com/#sprite), so we can start and stop animations and set static frames; and our custom `bump` component, so we can throw Mario off the screen if he dies.
 
-If we take a peek in the `Mario.json` file along with the `Mario.png` sprite file, we'll see that there are some animations defined in the `frameTags` section that we can use. The `Running` animation contains all the frames to make Mario appear to be running when he is in small size. Similarly, `RunningBig` has all the frames for when Mario is running while he is in big size. We can also see that a good frame for small Mario standing still, or stopped, is the first frame, or frame `0`. A good frame to use for big Mario standing still or stopped is frame `8`. Good frames for Mario jumping when he is small and big are `5` and `13` respectively. So we don't have to keep remembering all these magic strings and numbers, we set them as properties of the Mario component. 
+If we take a peek in the `Mario.json` file along with the `Mario.png` sprite file, we'll see that there are some animations defined in the `frameTags` section that we can use. The `Running` animation contains all the frames to make Mario appear to be running when he is in small size. Similarly, `RunningBig` has all the frames for when Mario is running while he is in big size. We can also see that a good frame for small Mario standing still, or stopped, is the first frame, or frame `0`. A good frame to use for big Mario standing still or stopped is frame `8`. Good frames for Mario jumping when he is small and big are `5` and `13` respectively. So we don't have to keep remembering all these magic strings and numbers, we set them as properties of the Mario component.
 
-If we measure the size of the big Mario images, we'll see that the tightest crop we can get on them is about 24x32 pixels. For small Mario, the size is 16x16 pixels. We'll use this knowledge to set the correct Mario animation and [`area`](https://kaboomjs.com/#area) collision boxes when changing between animations and sizes. 
+If we measure the size of the big Mario images, we'll see that the tightest crop we can get on them is about 24x32 pixels. For small Mario, the size is 16x16 pixels. We'll use this knowledge to set the correct Mario animation and [`area`](https://kaboomjs.com/#area) collision boxes when changing between animations and sizes.
 
-In the `mario` component, we define a number of custom methods. Let's go through them. 
+In the `mario` component, we define a number of custom methods. Let's go through them.
 
 - The `bigger` and `smaller` methods provide a way to change the size of Mario. We set a flag `isBig` that we check in the other methods to choose appropriate animations and frames. We also set the collision [`area`](https://kaboomjs.com/#area) size appropriate for the size of Mario.
-- The `standing` and `jumping` methods are called from our main `update` method, which is called with each frame. In these 2 methods, we stop any animation that is currently running using the `stop` method provided by the [`sprite`](https://kaboomjs.com/#sprite) component. Then, depending on the size of Mario, determined by the `isBig` flag, we set the appropriate static `frame` to make Mario look like he is standing still or jumping. 
-- In the `running` method, we find the correct running animation depending on whether Mario is big or small. Then we check if that animation is the same animation that Mario is currently using, by calling the `curAnim` method provided by the [`sprite`](https://kaboomjs.com/#sprite) component. If they are not the same, we update the current animation by calling `play` to start the new animation. We first check the current animation because, if we set the animation regardless of what is currently playing, we'd keep resetting the current animation to the beginning with each frame and make it appear as a static frame.  
+- The `standing` and `jumping` methods are called from our main `update` method, which is called with each frame. In these 2 methods, we stop any animation that is currently running using the `stop` method provided by the [`sprite`](https://kaboomjs.com/#sprite) component. Then, depending on the size of Mario, determined by the `isBig` flag, we set the appropriate static `frame` to make Mario look like he is standing still or jumping.
+- In the `running` method, we find the correct running animation depending on whether Mario is big or small. Then we check if that animation is the same animation that Mario is currently using, by calling the `curAnim` method provided by the [`sprite`](https://kaboomjs.com/#sprite) component. If they are not the same, we update the current animation by calling `play` to start the new animation. We first check the current animation because, if we set the animation regardless of what is currently playing, we'd keep resetting the current animation to the beginning with each frame and make it appear as a static frame.
 - The `freeze` method sets a flag `isFrozen`, which is used in the `update` method to determine whether Mario can move.
-- When Mario is killed, we can call the `die` method. This first removes the [`body`](https://kaboomjs.com/#body) component on Mario so that he is no longer subject to gravity or collisions, because these are things that ghosts are not worried about. Then we call the `bump` method that is added by our custom `bump` component. This shoots Mario up into the air, and back down again. We also set the `isAlive` flag to false, to signal to any collision handlers that Mario is dead before they try kill him again, or give him a 1-up mushroom or coin. We `freeze()` Mario so that he reverts to a standing pose and keyboard input doesn't affect him, and finally, we `use` the [`lifespan`](https://kaboomjs.com/#lifesspan) component to fade Mario out and remove him from the scene. 
+- When Mario is killed, we can call the `die` method. This first removes the [`body`](https://kaboomjs.com/#body) component on Mario so that he is no longer subject to gravity or collisions, because these are things that ghosts are not worried about. Then we call the `bump` method that is added by our custom `bump` component. This shoots Mario up into the air, and back down again. We also set the `isAlive` flag to false, to signal to any collision handlers that Mario is dead before they try kill him again, or give him a 1-up mushroom or coin. We `freeze()` Mario so that he reverts to a standing pose and keyboard input doesn't affect him, and finally, we `use` the [`lifespan`](https://kaboomjs.com/#lifesspan) component to fade Mario out and remove him from the scene.
 
-We also have the required `update` method, which Kaboom calls every frame. In this method, we check if Mario is frozen, in which case we call our `standing` method to update Mario's pose. Then we check if Mario is not on the ground, in other words he is in the air, using the `grounded()` method provided by the [`body`](https://kaboomjs.com/#body) component. This method returns `true` if he is on a `solid` object, or `false` otherwise. If this comes back `false`, we call the `jumping` method to stop any animations and set the static jumping frame. 
+We also have the required `update` method, which Kaboom calls every frame. In this method, we check if Mario is frozen, in which case we call our `standing` method to update Mario's pose. Then we check if Mario is not on the ground, in other words he is in the air, using the `grounded()` method provided by the [`body`](https://kaboomjs.com/#body) component. This method returns `true` if he is on a `solid` object, or `false` otherwise. If this comes back `false`, we call the `jumping` method to stop any animations and set the static jumping frame.
 
 If Mario is not jumping, i.e. he is `grounded`, then we check if the user currently has the `left` or `right` key down. If so, this means Mario is `running()`. The final condition is if Mario is on the ground but is not moving, then he must be `standing()`.
 
-Nice! Uncomment the `mario` component line in the `levelConf` to activate this new component on Mario. Update the output and test the animation changes out. Instead of Mario in a single pose, you should see an animation as he runs, changing to a static frame as he stands still or jumps. 
+Nice! Uncomment the `mario` component line in the `levelConf` to activate this new component on Mario. Update the output and test the animation changes out. Instead of Mario in a single pose, you should see an animation as he runs, changing to a static frame as he stands still or jumps.
 
-Now we can hook up collision handlers to check if Mario has eaten the mushroom to grow larger, or if he gets injured or killed by an enemy or falling off the screen. 
+Now we can hook up collision handlers to check if Mario has eaten the mushroom to grow larger, or if he gets injured or killed by an enemy or falling off the screen.
 
 ## Adding more Mario collisions and events
 
 First, let's add a collision handler between the mushroom and Mario. Then we can call our `bigger` method from our custom `mario` component to grow him.
 
 ```js
-player.collides("bigMushy", (mushy) => {
+player.onCollide("bigMushy", (mushy) => {
   destroy(mushy);
   player.bigger();
 });
 ```
 
-In this handler, we remove the mushroom from the scene, and then make Mario `bigger()`. 
+In this handler, we remove the mushroom from the scene, and then make Mario `bigger()`.
 
 Let's add some more code to the handler we created earlier for Mario colliding with an enemy. There, we only handled the case of Mario jumping on the enemy. We still need to account for Mario being injured or killed by the enemy. Update the `badGuy` collision handler like this:
 
 ```js
-player.collides("badGuy", (baddy) => {
+player.onCollide("badGuy", (baddy) => {
   if (baddy.isAlive == false) return;
   if (player.isAlive == false) return;
   if (canSquash) {
@@ -788,7 +788,7 @@ In the `else` condition, if Mario did not squash the bad guy, we check if we are
 ```js
 function killed() {
   // Mario is dead :(
-  if (player.isAlive == false) return; // Don't run it if mario is already dead 
+  if (player.isAlive == false) return; // Don't run it if mario is already dead
   player.die();
   add([
     text("Game Over :(", { size: 24 }),
@@ -803,12 +803,12 @@ function killed() {
 }
 ```
 
-This function does a few things. First, we run the code in the `die` method from the custom `mario` component. Then we [`add`](https://kaboomjs.com/#add) some [`text`](https://kaboomjs.com/#text) to notify the player that the game is over. We [`wait`](https://kaboomjs.com/#wait) for 2 seconds as we pay Mario our final respects, and then we [`go`](https://kaboomjs.com/#go) back to the start scene to play again. 
+This function does a few things. First, we run the code in the `die` method from the custom `mario` component. Then we [`add`](https://kaboomjs.com/#add) some [`text`](https://kaboomjs.com/#text) to notify the player that the game is over. We [`wait`](https://kaboomjs.com/#wait) for 2 seconds as we pay Mario our final respects, and then we [`go`](https://kaboomjs.com/#go) back to the start scene to play again.
 
-Another way Mario can die in *Mario World* is if he falls off the platform into the void. We can check for this by modifying the `player.action` handler we added earlier for moving the camera:
+Another way Mario can die in *Mario World* is if he falls off the platform into the void. We can check for this by modifying the `player.onUpdate` handler we added earlier for moving the camera:
 
 ```js
-player.action(() => {
+player.onUpdate(() => {
   // center camera to player
   var currCam = camPos();
   if (currCam.x < player.pos.x) {
@@ -832,13 +832,13 @@ Here, we check if Mario's `y` co-ordinate is greater than the [`height`](https:/
 We also need to update our `left` and `right` key handler events to check if Mario `isFrozen`. In this case the handlers should just return early without moving Mario:
 
 ```js
-    keyDown("right", () => {
+    onKeyDown("right", () => {
       if (player.isFrozen) return;
       player.flipX(false);
       player.move(SPEED, 0);
     });
 
-    keyDown("left", () => {
+    onKeyDown("left", () => {
       if (player.isFrozen) return;
       player.flipX(true);
       if (toScreen(player.pos).x > 20) {
@@ -850,7 +850,7 @@ We also need to update our `left` and `right` key handler events to check if Mar
 Then we also modify the `space` key handler to only jump if Mario is still alive:
 
 ```javascript
-keyPress("space", () => {
+onKeyPress("space", () => {
     if (player.isAlive && player.grounded()) {
       player.jump();
       canSquash = true;
@@ -858,13 +858,13 @@ keyPress("space", () => {
 });
 ```
 
-Time to update the output and test all these changes out! First thing to test is if Mario grows bigger by eating the mushroom. Second thing to check is if Mario then gets smaller again by colliding with an enemy. Also check if Mario is killed when colliding with an enemy when he is small, or when falling off the platform. 
+Time to update the output and test all these changes out! First thing to test is if Mario grows bigger by eating the mushroom. Second thing to check is if Mario then gets smaller again by colliding with an enemy. Also check if Mario is killed when colliding with an enemy when he is small, or when falling off the platform.
 
 ![Mario bigger and killed](/images/tutorials/32-mario-kaboom/bigger-kill-scenes.gif)
 
 ## Ending when we get to the castle
 
-The final thing to do for this tutorial is to handle the case when Mario reaches the castle. At this point, when Mario is at the door, we want him to `freeze`, a congratulations message to appear to the player, and then move on to the next level. 
+The final thing to do for this tutorial is to handle the case when Mario reaches the castle. At this point, when Mario is at the door, we want him to `freeze`, a congratulations message to appear to the player, and then move on to the next level.
 
 We can use a regular collision handler to check if Mario is at the castle. Notice in the setup for the castle in the `levelConf` we added earlier, we set the collision [`area`](https://kaboomjs.com/#area) of the castle to a very narrow, completely vertical line of width 1 pixel and height 240, which is the screen height:
 
@@ -874,19 +874,19 @@ We can use a regular collision handler to check if Mario is at the castle. Notic
     area({ width: 1, height: 240 }),
     origin("bot"),
     "castle"
-  ], 
+  ],
 ```
 
 This is so that the collision between Mario and the castle is only registered when Mario gets to the center of the castle, where the door is. We can visualize this by pressing F1 in the game to enable the debugger and look at the area box at the castle:
 
 ![castle area](/images/tutorials/32-mario-kaboom/castle.png)
 
-The reason we make the area box the height of the screen is make sure the player can't accidentally jump over the ending point and fall off the end of the level. 
+The reason we make the area box the height of the screen is make sure the player can't accidentally jump over the ending point and fall off the end of the level.
 
 Now let's add our collision handler for the castle to the game scene:
 
 ```js
-player.collides("castle", (castle, side) => {
+player.onCollide("castle", (castle, side) => {
   player.freeze();
   add([
     text("Well Done!", { size: 24 }),
@@ -907,7 +907,7 @@ player.collides("castle", (castle, side) => {
 });
 ```
 
-First, we `freeze` Mario so the player can't control him anymore. Then we [`add`](https://kaboomjs.com/#add) our "Well Done!" [`text`](https://kaboomjs.com/#text) message to the center of the screen. We [`wait`](https://kaboomjs.com/#wait) a second before incrementing our level number and going to the next level, or going back to the start of the game if we have completed all levels. 
+First, we `freeze` Mario so the player can't control him anymore. Then we [`add`](https://kaboomjs.com/#add) our "Well Done!" [`text`](https://kaboomjs.com/#text) message to the center of the screen. We [`wait`](https://kaboomjs.com/#wait) a second before incrementing our level number and going to the next level, or going back to the start of the game if we have completed all levels.
 
 
 ## Next steps
@@ -915,7 +915,7 @@ First, we `freeze` Mario so the player can't control him anymore. Then we [`add`
 There are few things left to do to complete the game:
 
 - Add in some scoring. You can check out a previous Kaboom tutorial, like [Space Shooter](https://docs.replit.com/tutorials/24-build-space-shooter-with-kaboom), to see how scoring works.
-- Add in sounds and music. If you get your own copy of the *Mario* soundtrack and effects, you can use the [`play`](https://kaboomjs.com/#play) sound function in Kaboom to get those classic tunes blasting as you play. 
+- Add in sounds and music. If you get your own copy of the *Mario* soundtrack and effects, you can use the [`play`](https://kaboomjs.com/#play) sound function in Kaboom to get those classic tunes blasting as you play.
 - Add in some more levels. This is the really fun part, where you get to create *Mario* levels you wish existed.
 - You can also add in some more of the *Mario World* game characters.
 


### PR DESCRIPTION
It's [suggested](https://github.com/replit/kaboom/blob/master/doc/releases/2000.1.0.md#toward-better-api-consistency) to use `on` prefix on event handlers since v2000.1 

Is it better to say "this tutorial uses kaboom v2000.1+" in front of each one?


(sorry my editor deletes trailing white spaces, please view with "hide whitespace")